### PR TITLE
merging over updates to msh clean from the dev branch

### DIFF
--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -1482,7 +1482,8 @@ classdef msh
         
    
         
-        function merge = plus(obj1,obj2)
+        function merge = plus(obj1,obj2,tight)
+            % merge = plus(obj1,obj2,tight)
             %%%%%%%%%%%%%%%%%%%%%%%%%%%%
             % Merge together two meshes contained in the msh objects obj1
             % and obj2. It uses MATLAB's implementation of the Boywer-Watson
@@ -1496,34 +1497,46 @@ classdef msh
             % ensure the mesh size functions are similar.
             %
             % INPUTS:
-            % mesh1: msh() class of inset mesh (INSET MUST BE FIRST).
-            % mesh2: msh() class of base mesh.
+            % obj1: msh() class of inset mesh (INSET MUST BE FIRST).
+            % obj2: msh() class of base mesh.
+            % tight: = 1 (default) updates boundary of obj2 (for removal of 
+            %          triangles) after removing intersection(obj1,obj2) 
+            %          from obj2 (best for merging overlapping and 
+            %          agreeable meshes)
+            %        = 0 does not update boundary of obj2 (for removal of 
+            %          triangles) after removing insersection(obj1,obj2) 
+            %          from obj2 (perhaps good for avoiding holes when
+            %          merging disparate resolution meshes)
+            %        = -1 does not remove intersection(obj1,obj2) from obj2
+            %          (assumes there is no overlap, best for merging
+            %          [almost] non-overlapping meshes)
             %
             % OUPUTS:
-            % a msh object in which the msh obj1's connectivity and bathymetry 
-            % is carried over (along with fixed points and edges from obj1).
+            % merge: a msh object in which the msh obj1's connectivity and 
+            % bathymetry is carried over (along with fixed points and edges
+            % from obj1).
             %
             % kjr, und, chl, sept. 2017 Version 1.0.
             % kjr, und, chl, oct. 2018, Version 1.5
             % kjr, usp. july 2019. Support for carrying over weirs and pfix. 
+            % wjp, inserting the 'tight' options optimizied for certain
+            % situations
             %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+            if nargin < 3
+                tight = 1;
+            end
+            
             p1 = obj1.p; t1 = obj1.t;
             p2 = obj2.p; t2 = obj2.t;
             
-            pfix1=[]; egfix1=[];
-            pfix2=[]; egfix2=[];
-            pfix=[];  egfix =[] ;
-            
-            pfix1  = obj1.pfix  ;   nfix1 = length(pfix1) ;
-            egfix1 = obj1.egfix ; negfix1 = length(egfix1) ;
-            pfix2  = obj2.pfix  ;   nfix2 = length(pfix2) ;
-            egfix2 = obj2.egfix ; negfix2 = length(egfix2) ;
+            pfix1 = obj1.pfix; nfix1 = length(pfix1); egfix1 = obj1.egfix; 
+            pfix2 = obj2.pfix; nfix2 = length(pfix2); egfix2 = obj2.egfix; 
             
             % all combined edge constraints 
             nfix   = nfix1+nfix2 ; 
-            egfix  = [egfix1 ; egfix2+nfix1] ; 
-            pfix   = [pfix1 ; pfix2] ;
+            egfixx  = [egfix1; egfix2+nfix1] ; 
+            pfixx   = [pfix1; pfix2] ;
             
             global MAP_PROJECTION MAP_COORDS MAP_VAR_LIST
             if ~isempty(obj2.coord)
@@ -1547,25 +1560,21 @@ classdef msh
             % project both meshes into the space of the global mesh
             [p1(:,1),p1(:,2)] = m_ll2xy(p1(:,1),p1(:,2)) ;
             [p2(:,1),p2(:,2)] = m_ll2xy(p2(:,1),p2(:,2)) ;
-            if nfix1 > 0
-              [pfix1(:,1),pfix1(:,2)] = m_ll2xy(pfix1(:,1),pfix1(:,2)) ;
-            end
-            if nfix2 > 0 
-              [pfix2(:,1),pfix2(:,2)] = m_ll2xy(pfix2(:,1),pfix2(:,2)) ;
-            end
             if nfix > 0
-              [pfix(:,1),pfix(:,2)] = m_ll2xy(pfix(:,1),pfix(:,2)) ;
+                [pfixx(:,1),pfixx(:,2)] = m_ll2xy(pfixx(:,1),pfixx(:,2)) ;
             end
             
             [~,d1] = ourKNNsearch(p1',p1',2);
-            avd1 = mean(d1(:,2)); mvd1 = max(d1(:,2));
             [~,d2] = ourKNNsearch(p2',p2',2);
-            avd2 = mean(d2(:,2)); mvd2 = max(d2(:,2));
+            mvd1 = max(d1); mvd2 = max(d2);
+            midi = min(min(d2),min(d1)); 
+            overlap = 0.5*(mvd1 + mvd2);
             
             disp('Forming outer boundary for base...')
             try
                 cell2 = extdom_polygon(extdom_edges2(t2,p2),p2,-1,0);
-                poly_vec2 = cell2mat(cell2');
+                poly_vec2 = cell2mat(cell2'); 
+                [edges2] = Get_poly_edges(poly_vec2);
             catch
                 error('Mesh 2 is invalid. Please execute msh.clean on object');
             end
@@ -1575,57 +1584,67 @@ classdef msh
             try
                 cell1 = extdom_polygon(extdom_edges2(t1,p1),p1,-1,0);
                 poly_vec1 = cell2mat(cell1');
+                [edges1] = Get_poly_edges(poly_vec1);
             catch
                 error('Mesh 1 is invalid. Please execute msh.clean on object');
             end
             
             % Delete the region in the global mesh that is in the
             % intersection with inset.
-            disp('Calculating intersection...');
-            [x3,y3] = polybool('intersection',...
-                poly_vec1(:,1),poly_vec1(:,2),poly_vec2(:,1),poly_vec2(:,2));
-            if ~isempty(x3)
-                poly_vec3 = [x3,y3]; poly_vec3(end+1,:) = NaN;
-                [edges3]  = Get_poly_edges(poly_vec3);
-                in1 = inpoly(p2(t2(:,1),:),poly_vec3,edges3);
-                in2 = inpoly(p2(t2(:,2),:),poly_vec3,edges3);
-                in3 = inpoly(p2(t2(:,3),:),poly_vec3,edges3);
-                t2(in1 & in2 & in3,:) = [];
-                % We need to delete straggling elements that are generated
-                % through the above deletion step
-                pruned2 = msh() ; pruned2.p = p2; pruned2.t = t2;
-                pruned2 = Make_Mesh_Boundaries_Traversable(pruned2,0.25,1);
-                t2 = pruned2.t; p2 = pruned2.p;
-                % get new poly_vec2
-                cell2 = extdom_polygon(extdom_edges2(t2,p2),p2,-1,0);
-                poly_vec2 = cell2mat(cell2');
+            if tight > -1
+                disp('Calculating intersection...');
+                [x3,y3] = polybool('intersection',...
+                    poly_vec1(:,1),poly_vec1(:,2),poly_vec2(:,1),poly_vec2(:,2));
+                if ~isempty(x3)
+                    poly_vec3 = [x3,y3]; poly_vec3(end+1,:) = NaN;
+                    [edges3]  = Get_poly_edges(poly_vec3);
+                    in1 = inpoly(p2(t2(:,1),:),poly_vec3,edges3);
+                    in2 = inpoly(p2(t2(:,2),:),poly_vec3,edges3);
+                    in3 = inpoly(p2(t2(:,3),:),poly_vec3,edges3);
+                    t2(in1 & in2 & in3,:) = [];
+                    % We need to delete straggling elements that are
+                    %  generated through the above deletion step
+                    pruned2 = msh() ; pruned2.p = p2; pruned2.t = t2;
+                    pruned2 = Make_Mesh_Boundaries_Traversable(pruned2,0.25,1);
+                    t2 = pruned2.t; p2 = pruned2.p;
+                    % get new poly_vec2
+                    if tight
+                        cell2 = extdom_polygon(extdom_edges2(t2,p2),p2,-1,0);
+                        poly_vec2 = cell2mat(cell2');
+                        [edges2] = Get_poly_edges(poly_vec2);
+                    end
+                end
             end
             pv1 = poly_vec1(~isnan(poly_vec1(:,1)),:);
             pv2 = poly_vec2(~isnan(poly_vec2(:,1)),:);
             
             disp('Merging...')
             if isempty(egfix1)
-                DTbase = delaunayTriangulation(p1(:,1),p1(:,2));
+                DTbase = delaunayTriangulation(p1);
             else
-                DTbase = delaunayTriangulation(p1(:,1),p1(:,2),egfix1);
+                DTbase = delaunayTriangulation(p1,egfix1);
             end
             DTbase.Points(end+(1:length(p2)),:) = p2;
+
+            % delete points that are too close together
+            [kk,dst] = ourKNNsearch(DTbase.Points',DTbase.Points',2);
+            dst = dst(:,2); kk = kk(:,2);
+            del = kk(dst < midi); 
+            DTbase.Points(double(unique(del)),:) = [];
             
             % ensure obj2's edge constraints are obeyed.
             if ~isempty(egfix2)
-                DTbase = delaunayTriangulation(DTbase.Points(:,1),DTbase.Points(:,2),...
-                    egfix2+length(p1));
+                DTbase = delaunayTriangulation(DTbase.Points,egfix2+length(p1));
                 % we must shuffle around the Points in DTbase to ensure all
                 % pfix are preprended at the top of the Points array.
                 pm = DTbase.Points ; 
                 tm = DTbase.ConnectivityList ; 
-                
-                pm = fixmesh([pfix; pm]) ; % this will delete points that are duplicate later on in the list
-                DTbase = delaunayTriangulation(pm,egfix);
+                pm = fixmesh([pfixx; pm]) ; % this will delete points that are duplicate later on in the list
+                DTbase = delaunayTriangulation(pm,egfixx);
             end
             
             tq.qm = 0;
-            while min(tq.qm) < 0.01
+            while min(tq.qm) < 1e-4
                 % Prune triangles outside both domains.
                 disp('Pruning...')
                 
@@ -1647,71 +1666,55 @@ classdef msh
                     pmid = (pm(tm(:,1),:)+pm(tm(:,2),:)+pm(tm(:,3),:))/3;
                     
                     %in1 is inside the inset boundary polygon
-                    [edges1] = Get_poly_edges(poly_vec1);
                     in1 = inpoly(pmid,poly_vec1,edges1);
                     
                     %in2 is inside the global boundary polygon
-                    [edges2] = Get_poly_edges(poly_vec2);
                     in2 = inpoly(pmid,poly_vec2,edges2);
                     
                     %in3 is inside the intersection
-                    if exist('poly_vec3','var')
+                    if exist('poly_vec3','var') && tight == 1
                         in3 = inpoly(pmid,poly_vec3,edges3);
                     else
-                        in3 = false(size(in1));
+                        in3 = false(size(in1)); 
                     end
                     
-                    % this tries to detect triangles in between close together
-                    % polygons to try and avoid creating holes
-                    [~,dst1] = ourKNNsearch(pv1',pmid',1);
-                    [~,dst2] = ourKNNsearch(pv2',pmid',1);
-                    in4      = dst1 < 0.5*(avd1 + avd2) & ...
-                        dst2 < 0.5*(avd1 + avd2);
-                    
-                    % remove triangles that aren't in the global mesh or
+                    % remove triangles that aren't in the global mesh or 
                     % aren't in the inset mesh
-                    inn = find((~in1 & ~in2 & ~in4) | (~in1 & in3));
-                    % this logic also tries to avoid creating holes
-                    % in the merged mesh
-                    del_nei = nei(inn,:);
-                    del1 = intersect(del_nei(:,1),inn);
-                    del2 = intersect(del_nei(:,2),inn);
-                    del3 = intersect(del_nei(:,3),inn);
-                    del = unique([del1; del2; del3]);
+                    del = (~in1 & ~in2) | (~in1 & in3);
                     tm(del,:) = [];
                 end
                 
                 merge = msh() ; merge.p = pm; merge.t = tm ;
-				merge = clean(merge,'passive','proj',0,'pfix',pfix);
+				merge = clean(merge,'passive','proj',0,'pfix',pfixx);
                 
                 % if we don't know the overlap region
                 [~,dst1] = ourKNNsearch(p1',merge.p',1);
                 [~,dst2] = ourKNNsearch(p2',merge.p',1);
-                idx = find(abs(dst1 - dst2) < 0.5*(mvd1 + mvd2));
+                idx = find(abs(dst1 - dst2) < overlap);
                 
                 % use smoother around intersection while obeying constraints)
                 constr = setdiff((1:length(merge.p))',idx);
                 if nfix > 0
-                  constr=[(1:nfix)'; constr] ; 
-                  [constr]=unique(constr);
+                   constr = [(1:nfix)'; constr] ; 
+                   constr = unique(constr);
                 end
                 [pm,tm] = smoothmesh(merge.p,merge.t,constr,50,0.01);
                 tq = gettrimeshquan(pm,tm);
                 disp(['min element quality is ', num2str(min(tq.qm))])
-                if min(tq.qm) < 0.01
+                if min(tq.qm) < 1e-4
                     DTbase = delaunayTriangulation(pm(:,1),pm(:,2));
                 end
             end
             
             merge.p = pm; merge.t = tm;
-            merge.pfix  = pfix ; merge.egfix = egfix ;
+            merge.pfix  = pfixx ; merge.egfix = egfixx ;
             
-             % convert back to lat-lon wgs84
+            % convert back to lat-lon wgs84
             [merge.p(:,1),merge.p(:,2)] = ...
                 m_xy2ll(merge.p(:,1),merge.p(:,2));
             if nfix > 0
                 [merge.pfix(:,1),merge.pfix(:,2)] = ...
-                    m_xy2ll(pfix(:,1),pfix(:,2));
+                    m_xy2ll(pfixx(:,1),pfixx(:,2));
             end
             
             merge.proj    = MAP_PROJECTION ;
@@ -1723,16 +1726,22 @@ classdef msh
             
             % Carry over bathy and gradients
             merge.b = 0*merge.p(:,1);
+            
             [idx1,dst1] = ourKNNsearch(obj1.p',merge.p',1);   
             [idx2,dst2] = ourKNNsearch(obj2.p',merge.p',1);   
-            merge.b(dst1 <= dst2) = obj1.b(idx1(dst1 <= dst2)); 
-            merge.b(dst2 <  dst1) = obj2.b(idx2(dst2 <  dst1)); 
+            merge.b( dst1 <= dst2) = obj1.b( idx1(dst1 <= dst2)); 
+            merge.b( dst2 <  dst1 ) = obj2.b( idx2(dst2 <  dst1) );
+            % ensure depth of the first mesh is preserved as a priority
+            in1 = inpoly(pm,poly_vec1,edges1);
+            merge.b( in1 ) = obj1.b( idx1(in1) ); 
             if ~isempty(obj1.bx) && ~isempty(obj2.bx)
                 merge.bx = 0*merge.b; merge.by = 0*merge.b;
-                merge.bx(dst1 <= dst2) = obj1.bx(idx1(dst1 <= dst2)); 
                 merge.bx(dst2 < dst1) = obj2.bx(idx2(dst2 < dst1)); 
-                merge.by(dst1 <= dst2) = obj1.by(idx1(dst1 <= dst2)); 
+                merge.bx(dst1 <= dst2) = obj1.bx(idx1(dst1 <= dst2)); 
+                merge.bx( in1 ) = obj1.bx( idx1(in1) ); 
                 merge.by(dst2 < dst1) = obj2.by(idx2(dst2 < dst1)); 
+                merge.by(dst1 <= dst2) = obj1.by(idx1(dst1 <= dst2)); 
+                merge.by( in1 ) = obj1.by( idx1(in1) ); 
             end
             disp(['Note that f13, f15 and boundary conditions etc. have' ...
                   'not been carried over into the merged mesh'])                                  

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -1501,15 +1501,17 @@ classdef msh
             % obj2: msh() class of base mesh.
             % tight: = 1 (default) updates boundary of obj2 (for removal of 
             %          triangles) after removing intersection(obj1,obj2) 
-            %          from obj2 (best for merging overlapping and 
-            %          agreeable meshes)
+            %          from obj2 (best for merging overlapping meshes that 
+            %          have similar resolution/mesh size functions)
             %        = 0 does not update boundary of obj2 (for removal of 
             %          triangles) after removing insersection(obj1,obj2) 
-            %          from obj2 (perhaps good for avoiding holes when
-            %          merging disparate resolution meshes)
+            %          from obj2 (good for avoiding holes when merging 
+            %          meshes with disparate resolution/mesh size functions)
             %        = -1 does not remove intersection(obj1,obj2) from obj2
             %          (assumes there is no overlap, best for merging
-            %          [almost] non-overlapping meshes)
+            %          [almost] non-overlapping meshes - ought to have 
+            %          matching or close to matching vertices but this is 
+            %          NOT a requirement)
             %
             % OUPUTS:
             % merge: a msh object in which the msh obj1's connectivity and 


### PR DESCRIPTION
- updates to the msh cleaner enabling a 'tight' option tailored to certain conditions such as overlapping meshes with similar mesh resolution, overlapping with disparate mesh resolution, and (almost) non-overlapping meshes.
- removed the previous lines which tried to avoid holes but that created other issues for well-matched meshes.
- new version also deletes points too close together and preserves the depths inside msh obj1 as a priority.