### PR TITLE
Improvements to plus/merger algorithm 

### DIFF
--- a/@geodata/geodata.m
+++ b/@geodata/geodata.m
@@ -58,7 +58,7 @@ classdef geodata
               M_MAP_EXISTS=1 ;
             end
             if M_MAP_EXISTS~=1 
-              error('Where''s m_map? Chief, you need to read the user guide')
+              error('Where''s m_map? Please read the user guide')
             end
 
             % Check for utilties dir
@@ -67,7 +67,7 @@ classdef geodata
               UTIL_DIR_EXISTS=1; 
             end
             if UTIL_DIR_EXISTS~=1 
-              error('Where''s the utilities directory? Chief, you need to read the user guide')
+              error('Where''s the utilities directory? Please read the user guide')
             end
 
             % Check for dataset dir
@@ -76,7 +76,7 @@ classdef geodata
                 DATASET_DIR_EXISTS=1 ;
             end
             if DATASET_DIR_EXISTS~=1
-                warning('We suggest you to place your files in a datasets directory. Chief, you need to read the user guide')
+                warning('We suggest you to place your files in a directory called "datasets". Please read the user guide')
             end
 
 

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -49,7 +49,7 @@ classdef msh
               M_MAP_EXISTS=1 ;
             end
             if M_MAP_EXISTS~=1 
-              error('Where''s m_map? Chief, you need to read the user guide')
+              error('Where''s m_map? Please read the user guide')
             end
 
             % Check for utilties dir
@@ -58,7 +58,7 @@ classdef msh
               UTIL_DIR_EXISTS=1 ;
             end
             if UTIL_DIR_EXISTS~=1 
-              error('Where''s the utilities directory? Chief, you need to read the user guide')
+              error('Where''s the utilities directory? Please read the user guide')
             end
             
             % Check for dataset dir
@@ -67,7 +67,7 @@ classdef msh
                 DATASET_DIR_EXISTS=1 ;
             end
             if DATASET_DIR_EXISTS~=1
-                warning('We suggest you to place your files in a datasets directory. Chief, you need to read the user guide')
+                warning('We suggest you to place your files in a datasets directory. Please read the user guide')
             end
 
             if nargin == 0
@@ -1513,16 +1513,17 @@ classdef msh
             %
             % OUPUTS:
             % merge: a msh object in which the msh obj1's connectivity and 
-            % bathymetry is carried over (along with fixed points and edges
-            % from obj1).
+            % bathymetry is carried over (along with fixed points
+            % from obj1 and obj2).
             %
             % kjr, und, chl, sept. 2017 Version 1.0.
             % kjr, und, chl, oct. 2018, Version 1.5
             % kjr, usp. july 2019. Support for carrying over weirs and pfix. 
             % wjp, inserting the 'tight' options optimizied for certain
             % situations
+            % kjr, usp. nov 2019. Better merging wrt to fixed constraints. 
+            %                     now collapses thin triangles incrementally 
             %%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
             if nargin < 3
                 tight = 1;
             end
@@ -1530,12 +1531,11 @@ classdef msh
             p1 = obj1.p; t1 = obj1.t;
             p2 = obj2.p; t2 = obj2.t;
             
-            pfix1 = obj1.pfix; nfix1 = length(pfix1); egfix1 = obj1.egfix; 
-            pfix2 = obj2.pfix; nfix2 = length(pfix2); egfix2 = obj2.egfix; 
+            pfix1 = obj1.pfix; nfix1 = length(pfix1); 
+            pfix2 = obj2.pfix; nfix2 = length(pfix2); 
             
             % all combined edge constraints 
-            nfix   = nfix1+nfix2 ; 
-            egfixx  = [egfix1; egfix2+nfix1] ; 
+            nfix    = nfix1+nfix2 ; 
             pfixx   = [pfix1; pfix2] ;
             
             global MAP_PROJECTION MAP_COORDS MAP_VAR_LIST
@@ -1563,12 +1563,7 @@ classdef msh
             if nfix > 0
                 [pfixx(:,1),pfixx(:,2)] = m_ll2xy(pfixx(:,1),pfixx(:,2)) ;
             end
-            
-            [~,d1] = ourKNNsearch(p1',p1',2);
-            [~,d2] = ourKNNsearch(p2',p2',2);
-            mvd1 = max(d1); mvd2 = max(d2);
-            midi = min(min(d2),min(d1)); 
-            overlap = 0.5*(mvd1 + mvd2);
+           
             
             disp('Forming outer boundary for base...')
             try
@@ -1582,7 +1577,8 @@ classdef msh
             
             disp('Forming outer boundary for inset...')
             try
-                cell1 = extdom_polygon(extdom_edges2(t1,p1),p1,-1,0);
+                [cell1,~,max_index] = extdom_polygon(extdom_edges2(t1,p1),p1,-1,0);
+                bigInset=cell1{max_index};
                 poly_vec1 = cell2mat(cell1');
                 [edges1] = Get_poly_edges(poly_vec1);
             catch
@@ -1605,8 +1601,10 @@ classdef msh
                     % We need to delete straggling elements that are
                     %  generated through the above deletion step
                     pruned2 = msh() ; pruned2.p = p2; pruned2.t = t2;
-                    pruned2 = Make_Mesh_Boundaries_Traversable(pruned2,0.25,1);
-                    t2 = pruned2.t; p2 = pruned2.p;
+                    % kjr, the dj_cutoff in the following call was lowered to
+                    % 0.01!
+                    pruned2 = Make_Mesh_Boundaries_Traversable(pruned2,0.01,1);
+                    t2 = pruned2.t; p2 = pruned2.p;                    
                     % get new poly_vec2
                     if tight
                         cell2 = extdom_polygon(extdom_edges2(t2,p2),p2,-1,0);
@@ -1615,33 +1613,10 @@ classdef msh
                     end
                 end
             end
-            pv1 = poly_vec1(~isnan(poly_vec1(:,1)),:);
-            pv2 = poly_vec2(~isnan(poly_vec2(:,1)),:);
             
             disp('Merging...')
-            if isempty(egfix1)
-                DTbase = delaunayTriangulation(p1);
-            else
-                DTbase = delaunayTriangulation(p1,egfix1);
-            end
+            DTbase = delaunayTriangulation(p1);
             DTbase.Points(end+(1:length(p2)),:) = p2;
-
-            % delete points that are too close together
-            [kk,dst] = ourKNNsearch(DTbase.Points',DTbase.Points',2);
-            dst = dst(:,2); kk = kk(:,2);
-            del = kk(dst < midi); 
-            DTbase.Points(double(unique(del)),:) = [];
-            
-            % ensure obj2's edge constraints are obeyed.
-            if ~isempty(egfix2)
-                DTbase = delaunayTriangulation(DTbase.Points,egfix2+length(p1));
-                % we must shuffle around the Points in DTbase to ensure all
-                % pfix are preprended at the top of the Points array.
-                pm = DTbase.Points ; 
-                tm = DTbase.ConnectivityList ; 
-                pm = fixmesh([pfixx; pm]) ; % this will delete points that are duplicate later on in the list
-                DTbase = delaunayTriangulation(pm,egfixx);
-            end
             
             tq.qm = 0;
             while min(tq.qm) < 1e-4
@@ -1661,7 +1636,6 @@ classdef msh
                     end
                     
                     pm = DTbase.Points; tm = DTbase.ConnectivityList;
-                    nei = DTbase.neighbors;
                     
                     pmid = (pm(tm(:,1),:)+pm(tm(:,2),:)+pm(tm(:,3),:))/3;
                     
@@ -1685,33 +1659,33 @@ classdef msh
                 end
                 
                 merge = msh() ; merge.p = pm; merge.t = tm ;
-				merge = clean(merge,'passive','proj',0,'pfix',pfixx);
+                merge = clean(merge,'passive','proj',0,'pfix',pfixx);
                 
-                % if we don't know the overlap region
-                [~,dst1] = ourKNNsearch(p1',merge.p',1);
-                [~,dst2] = ourKNNsearch(p2',merge.p',1);
-                idx = find(abs(dst1 - dst2) < overlap);
+                % kjr, collapse small triangles together 
+                [merge.p,merge.t]=collapse_thin_triangles(merge.p,merge.t,0.25); 
+
+                % kjr, do a direct smooth on everything inside of an enlarged convex hull
+                % of the inset. 
+                k=convhull(bigInset(1:end-1,1),bigInset(1:end-1,2));
+                xout=bigInset(k,1); yout=bigInset(k,2);
+                [xe,ye]=enlargePoly(xout,yout,1.35);
+                in=inpoly(merge.p,[xe,ye]);
+                constrIdx = find(~in); locked=[merge.p(constrIdx,:); pfixx];
+                [pm,tm] = direct_smoother_lur(merge.p,merge.t,locked,0);
                 
-                % use smoother around intersection while obeying constraints)
-                constr = setdiff((1:length(merge.p))',idx);
-                if nfix > 0
-                   constr = [(1:nfix)'; constr] ; 
-                   constr = unique(constr);
-                end
-                [pm,tm] = smoothmesh(merge.p,merge.t,constr,50,0.01);
                 tq = gettrimeshquan(pm,tm);
                 disp(['min element quality is ', num2str(min(tq.qm))])
-                if min(tq.qm) < 1e-4
-                    DTbase = delaunayTriangulation(pm(:,1),pm(:,2));
-                end
             end
             
             merge.p = pm; merge.t = tm;
-            merge.pfix  = pfixx ; merge.egfix = egfixx ;
+            merge.pfix  = pfixx ; 
+            % edges don't move but they are no longer valid after merger
+            merge.egfix = [];
             
             % convert back to lat-lon wgs84
             [merge.p(:,1),merge.p(:,2)] = ...
                 m_xy2ll(merge.p(:,1),merge.p(:,2));
+
             if nfix > 0
                 [merge.pfix(:,1),merge.pfix(:,2)] = ...
                     m_xy2ll(pfixx(:,1),pfixx(:,2));
@@ -1746,7 +1720,8 @@ classdef msh
             disp(['Note that f13, f15 and boundary conditions etc. have' ...
                   'not been carried over into the merged mesh'])                                  
         end
-      
+
+                  
         function obj = CheckElementOrder(obj,proj)
             if nargin == 1
                proj = 0; 

--- a/utilities/Make_Mesh_Boundaries_Traversable.m
+++ b/utilities/Make_Mesh_Boundaries_Traversable.m
@@ -65,7 +65,7 @@ p = obj.p; t = obj.t;
 
 % WJP sometimes we may wanna delete some exterior portions even with a valid
 % mesh so allow entry even in this case.
-if numel(etbv) == numel(vxe)
+if dj_cutoff > 0 && numel(etbv) == numel(vxe)
     etbv(end+1,:) = 1; 
 end
 % Loop until all the nodes only have two boundary edges
@@ -107,6 +107,14 @@ end
 % dj_cutoff < 1
 %    proportion of the total mesh area
 function t = delete_exterior_elements(p,t,dj_cutoff,nscreen)
+%
+if dj_cutoff <= 0
+    if nscreen
+        disp('dj_cutoff is zero; do nothing in delete_exterior_elements')
+    end
+    % do nothing
+    return; 
+end
 L = size(t,1); 
 t1 = t; t = [];
 global MAP_PROJECTION

--- a/utilities/collapse_thin_triangles.m
+++ b/utilities/collapse_thin_triangles.m
@@ -1,0 +1,40 @@
+function [pc,tc]=collapse_thin_triangles(p,t,minqm)
+% Collapse triangles that are exceedingly thin incrementally modifying the 
+% connectivity.
+% Thin triangles are identified by containing highly actue angles.
+% The shortest edge of the identified triangle is collapsed to a point.
+% and the triangle table and point matrix are updated accordingly.
+% kjr, usp,br. 2019.
+
+if nargin < 3
+    minqm = 0.10 ; % minimum quality to identify thin triangles
+end
+tq = gettrimeshquan(p,t);
+
+kount=1;
+while any(tq.qm < minqm)
+    
+    id = find(tq.qm < minqm); % queue
+
+    tid=id(1);
+    tlocal=t(tid,:);
+    ee = [tlocal(1,[1,2]); tlocal(1,[1,3]); tlocal(1,[2,3])];
+    evec = p(ee(:,1),:)- p(ee(:,2),:);
+    [~,meid]=min(sum(evec.^2,2)); % find shortest edge
+    
+    PointIDToRemove=ee(meid,1) ; % remove this id for ReplaceID 
+    PointIDToReplace=ee(meid,2); % replace remove ID with this id 
+ 
+    % Delete triangle that has the thin edge for deletion
+    t(tid,:)=[]; 
+    % Replace all other instances of PointIDToRemove with PointIDToReplace 
+    t(t==PointIDToRemove)=PointIDToReplace;  
+
+     % recompute qualities. 
+    tq = gettrimeshquan(p,t);
+    kount=kount+1; 
+end
+[pc,tc]=fixmesh(p,t); % remove hanging points 
+disp(['Removed ',num2str(kount),' thin triangles!']); 
+
+

--- a/utilities/enlargePoly.m
+++ b/utilities/enlargePoly.m
@@ -1,0 +1,5 @@
+function [xout,yout]=enlargePoly(x,y,frac)
+% Enlarges a NaN-delimited polygon by a fractional amount
+xout = frac*x+(1-frac)*nanmean(x);
+yout = frac*y+(1-frac)*nanmean(y);
+

--- a/utilities/setProj.m
+++ b/utilities/setProj.m
@@ -45,6 +45,7 @@ function [del] = setProj(obj,proj,projtype)
         if ~ischar(projtype)
             projtype = projtype{1};
         end
+        projtype = lower(projtype);
         if ~isempty(regexp(projtype,'ste'))
             % Special treatment of Stereographic projection
             if lat_ma < 0


### PR DESCRIPTION
1. Made errors friendlier.
2. Improved merger msh.plus() method by:
   -Incrementally collapsing "thin" triangles (see collapse_thin_triangles.m)
    This is now in lieu of deleting arbitrarily close points.
   -Doing a direct smooth in an region around the
   inset-to-be-merged in lieu of a smart Laplacian.
3. Improved preservation of fixed points when merging as well.