### PR TITLE
Further updates to msh plus

### DIFF
--- a/@meshgen/meshgen.m
+++ b/@meshgen/meshgen.m
@@ -413,11 +413,14 @@ classdef meshgen
                     dataset = obj.outer{box_num};
                     dataset(isnan(obj.outer{box_num}(:,1)),:) = [];
                 end
+                if all(abs(obj.bbox{box_num}(1,:)) == 180)
+                    % This line removes the line that can appear in the 
+                    % center for a global mesh
+                    dataset(abs(dataset(:,1)) > 180-1e-6,:) = [];
+                    dataset(abs(dataset(:,1)) < 1e-6,:) = [];
+                end
                 [dataset(:,1),dataset(:,2)] = m_ll2xy(dataset(:,1),dataset(:,2));
                 dataset(isnan(dataset(:,1)),:) = [];
-                % This line removes the line that can appear in the center for
-                % stereo projection from the bbox
-                dataset(abs(dataset(:,1)) < 1e-6,:) = [];
                 dmy = ann(dataset');
                 obj.anno{box_num} = dmy;
                 obj.annData{box_num}=dataset; 

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -1629,7 +1629,11 @@ classdef msh
                     MAP_COORDS     = obj2.coord ;
                 end
             else
-                projname = 'stereo';
+                if max(abs(obj2.p(:,2)) > 85)
+                    projname = 'stereo';
+                else
+                    projname = 'equi';
+                end
                 setProj(obj2,1,projname);
             end
            

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -507,6 +507,7 @@ classdef msh
                             desiredTicks = round(10.^(linspace(min(q),...
                                                  max(q),numticks(1))),-1);
                         end
+                        desiredTicks=unique(desiredTicks); 
                         caxis([log10(min(desiredTicks)) log10(max(desiredTicks))]);
                         cb.Ticks     = log10(desiredTicks);
                         for i = 1 : length(desiredTicks)

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -753,58 +753,6 @@ classdef msh
                     end
                     obj.bd.ibconn = ibconn;
                 end
-                
-                if isfield(obj.bd,'barinht')
-                    for ib = 1 : obj.bd.nbou
-                        tempcell{ib} = obj.bd.barinht(1:obj.bd.nvell(ib),ib);
-                    end
-                    temp = cell2mat(tempcell');
-                    ex   = find(temp~=0) ;
-                    temp(ex) = perm_inv(temp(ex))';
-                    temp = mat2cell(temp,cellfun(@length,tempcell));
-                    barinht = zeros(size(obj.bd.nbvv,1),size(obj.bd.nbvv,2));
-                    for ib = 1 : obj.bd.nbou
-                        for iv = 1 : obj.bd.nvell(ib)
-                            barinht(iv,ib) = temp{ib}(iv,:);
-                        end
-                    end
-                    obj.bd.barinht = barinht;
-                end
-                
-                if isfield(obj.bd,'barincfsb')
-                    for ib = 1 : obj.bd.nbou
-                        tempcell{ib} = obj.bd.barincfsb(1:obj.bd.nvell(ib),ib);
-                    end
-                    temp = cell2mat(tempcell');
-                    ex   = find(temp~=0) ;
-                    temp(ex) = perm_inv(temp(ex))';
-                    temp = mat2cell(temp,cellfun(@length,tempcell));
-                    barincfsb = zeros(size(obj.bd.nbvv,1),size(obj.bd.nbvv,2));
-                    for ib = 1 : obj.bd.nbou
-                        for iv = 1 : obj.bd.nvell(ib)
-                            barincfsb(iv,ib) = temp{ib}(iv,:);
-                        end
-                    end
-                    obj.bd.barincfsb = barincfsb;
-                end
-                
-                if isfield(obj.bd,'barincfsp')
-                    for ib = 1 : obj.bd.nbou
-                        tempcell{ib} = obj.bd.barincfsp(1:obj.bd.nvell(ib),ib);
-                    end
-                    temp = cell2mat(tempcell');
-                    ex   = find(temp~=0) ;
-                    temp(ex) = perm_inv(temp(ex))';
-                    temp = mat2cell(temp,cellfun(@length,tempcell));
-                    barincfsp = zeros(size(obj.bd.nbvv,1),size(obj.bd.nbvv,2));
-                    for ib = 1 : obj.bd.nbou
-                        for iv = 1 : obj.bd.nvell(ib)
-                            barincfsp(iv,ib) = temp{ib}(iv,:);
-                        end
-                    end
-                    obj.bd.barincfsb = barincfsp;
-                end
-                
             end
             
             if ~isempty(obj.f13)

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -599,6 +599,7 @@ classdef msh
                             m_trisurf(obj.t,obj.p(:,1),obj.p(:,2),alltogether(kept));
                         else
                             trisurf(obj.t,obj.p(:,1),obj.p(:,2),alltogether(kept));
+                            view(2); shading flat
                         end
                         nouq = length(unique(values));
                         colormap(jet(nouq));

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -1725,9 +1725,9 @@ classdef msh
                     in3 = inpoly(p2(t2(:,3),:),poly_vec3,edges3);
                     t2(in1 & in2 & in3,:) = [];
                     % We need to delete straggling elements that are
-                    %  generated through the above deletion step
+                    % generated through the above deletion step
                     pruned2 = msh() ; pruned2.p = p2; pruned2.t = t2;
-                    pruned2 = Make_Mesh_Boundaries_Traversable(pruned2,0,1);
+                    pruned2 = Make_Mesh_Boundaries_Traversable(pruned2,0.01,1);
                     t2 = pruned2.t; p2 = pruned2.p;                    
                     % get new poly_vec2
                     if strcmp(type,'arb')

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -516,6 +516,7 @@ classdef msh
                     elseif length(numticks) == 3
                         caxis([numticks(2) numticks(3)]);
                     end
+                    set(gca,'FontSize',16)
                     ylabel(cb,'element circumradius [m]','fontsize',15);
                     title('mesh resolution');
                 case('resodx')
@@ -1855,12 +1856,22 @@ classdef msh
                 [nr2,nc2]=size(obj1.bd.nbvv);
                 nbvv_old = merge.bd.nbvv;
                 ibconn_old = merge.bd.ibconn;
+                barinht_old = merge.bd.barinht; 
+                barincfsb_old = merge.bd.barincfsb; 
+                barincfsp_old = merge.bd.barincfsp; 
                 
                 merge.bd.nbvv = zeros(max(nr1,nr2),max(nc1,nc1+nc2));
                 merge.bd.ibconn = zeros(max(nr1,nr2),max(nc1,nc1+nc2));
-                
+                merge.bd.barinht = zeros(max(nr1,nr2),max(nc1,nc1+nc2));
+                merge.bd.barincfsb = zeros(max(nr1,nr2),max(nc1,nc1+nc2));
+                merge.bd.barincfsp = zeros(max(nr1,nr2),max(nc1,nc1+nc2));
+
                 merge.bd.nbvv(1:nr1,1:nc1)=nbvv_old;
                 merge.bd.ibconn(1:nr1,1:nc1)=ibconn_old;
+                merge.bd.barinht(1:nr1,1:nc1)=barinht_old; 
+                merge.bd.barincfsb(1:nr1,1:nc1)=barincfsb_old; 
+                merge.bd.barincfsp(1:nr1,1:nc1)=barincfsp_old;
+                
                 
                 % remap
                 for ii = startBou:merge.bd.nbou
@@ -1868,9 +1879,10 @@ classdef msh
                     idx = ii - (startBou-1) ;
                     nodes =  full(obj1.bd.nbvv(1:obj1.bd.nvell(idx),idx));
                     nodes2 = full(obj1.bd.ibconn(1:obj1.bd.nvell(idx),idx));
-                    
+
                     merge.bd.nbvv(1:merge.bd.nvell(ii),ii)   = idx1(nodes);
                     merge.bd.ibconn(1:merge.bd.nvell(ii),ii) = idx1(nodes2);
+
                 end
             end
             
@@ -1902,12 +1914,21 @@ classdef msh
                 [nr2,nc2]=size(obj2.bd.nbvv);
                 nbvv_old = merge.bd.nbvv;
                 ibconn_old = merge.bd.ibconn;
+                barinht_old = merge.bd.barinht; 
+                barincfsb_old = merge.bd.barincfsb; 
+                barincfsp_old = merge.bd.barincfsp; 
                 
                 merge.bd.nbvv = zeros(max(nr1,nr2),max(nc1,nc1+nc2));
                 merge.bd.ibconn = zeros(max(nr1,nr2),max(nc1,nc1+nc2));
+                merge.bd.barinht = zeros(max(nr1,nr2),max(nc1,nc1+nc2));
+                merge.bd.barincfsb = zeros(max(nr1,nr2),max(nc1,nc1+nc2));
+                merge.bd.barincfsp = zeros(max(nr1,nr2),max(nc1,nc1+nc2));
                 
                 merge.bd.nbvv(1:nr1,1:nc1)=nbvv_old;
                 merge.bd.ibconn(1:nr1,1:nc1)=ibconn_old;
+                merge.bd.barinht(1:nr1,1:nc1)=barinht_old;
+                merge.bd.barincfsb(1:nr1,1:nc1)=barincfsb_old;
+                merge.bd.barincfsp(1:nr1,1:nc1)=barincfsp_old;
                 
                 % remap
                 for ii = startBou:merge.bd.nbou

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -1621,7 +1621,7 @@ classdef msh
             end
 
             % checking for weirs in obj1 to keep
-            if any(obj1.bd.ibtype == 24)
+            if ~isempty(obj1.bd) && any(obj1.bd.ibtype == 24)
                 disp('Weirs found in obj1, extracting to ensure they are preserved')
                 % get the weir indices
                 weir_nodes = [];
@@ -1774,7 +1774,7 @@ classdef msh
             merge.egfix = [];
            
             % put the weirs back
-            if any(obj1.bd.ibtype == 24)
+            if ~isempty(obj1.bd) && any(obj1.bd.ibtype == 24)
                 disp('Putting the weirs back into merged obj')
                 % edit weir tri for duplicate points and renumbering
                 [~,d] = ourKNNsearch(pw',pw',2);
@@ -1843,7 +1843,7 @@ classdef msh
                 end
             end
             
-            if any(obj1.bd.ibtype == 24)
+            if ~isempty(obj1.bd) && any(obj1.bd.ibtype == 24)
                 disp('Carrying over obj1 weir nodestrings.')
                 idx1 = ourKNNsearch(merge.p',obj1.p',1);  
                 merge.bd = obj1.bd;

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -818,6 +818,46 @@ classdef msh
         
         % interp bathy/slope
         function obj = interp(obj,geodata,varargin)
+            % obj = interp(obj,geodata,varargin)
+            % Puts bathy and slopes on the msh obj (a wrapper for GridData). 
+            % 'geodata' input may be a geodata class or a netCDF dem filename char.
+            % 'geodata' may also be a cell array of geodata classes and dems and
+            % interp will loop over all them. 
+            % 
+            % optional varargins are as follows (copied from GridData):
+            %          K - vector of relevant nodes to search. This can
+            %                         significantly speed up the calculation by either 
+            %                         only interpolating part of the mesh or 
+            %                         intepolating whole mesh but in segments. Function
+            %                         automatically removes uncessary portions of DEM
+            %                         Example to call: 
+            %                         K = find( obj.p(:,1) >= lon_min & ...
+            %                                   obj.p(:,2) <= lon_max);
+            %                         obj = interp(obj,dem,'K',K);
+            %
+            %       type - type is either 'depth', 'slope' or 'all'
+            %                         'all' is the default (both slope and depth). 
+            %                         'slope' to gets the gradients of DEM
+            %
+            %     interp - interp is either the normal griddedInterpolant
+            %                         options in MATLAB or is 'CA' (default). Note: 'CA'
+            %                         applies linear griddedInterpolant when the DEM
+            %                         and grid sizes are similar. 
+            %
+            %          N - enlarge cell-averaging stencil by factor N (only 
+            %                         relevant for CA interpolation method). 
+            %                         default value N=1. 
+            %
+            %        nan - 'fill' to fill in any NaNs appearing in bathy
+            %
+            %   mindepth - ensure the minimum depth is bounded in the 
+            %                         interpolated region 
+            %
+            %   maxdepth - ensure the maximum depth is bounded in the 
+            %                         interpolated region 
+            %
+            %   ignoreOL - NaN overland data for more accurate seabed interpolation
+
             % if give cell of geodata or dems then interpolate all
             if iscell(geodata) || isstring(geodata)
                 for i = 1:length(geodata)

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -1775,7 +1775,20 @@ classdef msh
             % put the weirs back
             if any(obj1.bd.ibtype == 24)
                 disp('Putting the weirs back into merged obj')
-                tw = tw + length(merge.p);
+                % edit weir tri for duplicate points and renumbering
+                [~,d] = ourKNNsearch(pw',pw',2);
+                d = d(:,2); mind = min(d);
+                [idx,d] = ourKNNsearch(merge.p',pw',1);
+                tw1 = tw; % to make sure we don't double mix up ourselves
+                for ii = 1:size(pw,1)
+                    if d(ii) < mind
+                        % really close (closer than distance across weir)
+                        tw(tw1 == ii) = idx(ii);
+                    else
+                        % not close
+                        tw(tw1 == ii) = ii + length(merge.p);
+                    end
+                end
                 merge.p = [merge.p; pw];
                 merge.t = [merge.t; tw];
                 [merge.p, merge.t] = fixmesh(merge.p,merge.t);

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -875,12 +875,12 @@ classdef msh
             elseif any(strcmp(varargin,'aggressive'))
                 disp('Employing aggressive option')
                 opt.db = 0.5; opt.ds = 1; opt.con = 9; opt.djc = 0.25; 
-                opt.sc_maxit = inf; opt.mqa = 0.1;
+                opt.sc_maxit = inf; opt.mqa = 0.5;
                 varargin(strcmp(varargin,'aggressive')) = [];
             else
                 disp('Employing default (medium) option or user-specified opts')
                 opt.db = 0.25; opt.ds = 1; opt.con = 9; opt.djc = 0.1; 
-                opt.sc_maxit = 1; opt.mqa = 0.025;
+                opt.sc_maxit = inf; opt.mqa = 0.25;
                 varargin(strcmp(varargin,'default')) = []; 
                 varargin(strcmp(varargin,'medium')) = []; 
             end

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -987,11 +987,11 @@ classdef msh
             obj = renum(obj);
             % May not always work without error
             if opt.con > 6
-                %try
+                try
                    obj = bound_con_int(obj,opt.con);
-                %catch
-                %   warning('Could not reduce connectivity mesh');
-                %end
+                catch
+                   warning('Could not reduce connectivity mesh');
+                end
             end
            
             % Now do the smoothing if required

--- a/utilities/Nodal_Reduce_Matlab_Codes/patch_update.m
+++ b/utilities/Nodal_Reduce_Matlab_Codes/patch_update.m
@@ -70,9 +70,14 @@ zt1 = [z0;zin(:)];
 [in,on] = inpolygon(xt1,yt1,xex,yex);
 I = find(in == 0 | on == 1);
 while ~isempty(I)
-    xt1(I) = (xt1(I) + oldfem.x(jj))./2;
-    yt1(I) = (yt1(I) + oldfem.y(jj))./2;
-    zt1(I) = (zt1(I) + oldfem.z(jj))./2;
+    nd = (yt1(I) - oldfem.y(jj)) + (xt1(I) -  oldfem.x(jj));
+    if nd == 0
+        % can't do anything
+        fem = newfem; return;
+    end
+    xt1(I) = (xt1(I) + oldfem.x(jj))/2;
+    yt1(I) = (yt1(I) + oldfem.y(jj))/2;
+    zt1(I) = (zt1(I) + oldfem.z(jj))/2;
     [in,on] = inpolygon(xt1,yt1,xex,yex);
     I = find(in == 0 | on == 1);
 end

--- a/utilities/Nodal_Reduce_Matlab_Codes/update10nbr.m
+++ b/utilities/Nodal_Reduce_Matlab_Codes/update10nbr.m
@@ -65,8 +65,7 @@ newnode = nnodes + [1:3];
 newelem = nelems + [1:6];
 badnode = jj;
 nbrnode = nei(jj,1:10);
-[nbrelem,J] = find(enodes == badnode);
-clear J;
+[nbrelem,~] = find(enodes == badnode);
 inrad = max(sqrt((x(nbrnode)-x(badnode)).^2 + (y(nbrnode)-y(badnode)).^2));
 
 %First guess of the new coordinates and bathymetry.
@@ -103,15 +102,17 @@ z(newnode(3)) = Dz;
 %Updates the effected elements. J variables are used to represent which
 %elements are connected each node.
 i = 1;
-while i <= 8;
-j1 = ismember((enodes((nbrelem),:)),(nbrnode(vod(i))));
-j2 = ismember((enodes((nbrelem),:)),(nbrnode(vod(i+1))));
-spb = [1,1,1,2,2,3,3,3];
-j = sum([j1,j2],2);
-temp = nbrelem(find (j == 2));
-enodes(temp,:) = ([nbrnode(vod(i)),nbrnode(vod(i+1)),newnode(spb(i))]);
-i = i + 1;
-clear j j1 j2 temp;
+while i <= 8
+    j1 = ismember((enodes((nbrelem),:)),(nbrnode(vod(i))));
+    j2 = ismember((enodes((nbrelem),:)),(nbrnode(vod(i+1))));
+    spb = [1,1,1,2,2,3,3,3];
+    j = sum([j1,j2],2);
+    temp = nbrelem(find (j == 2));
+    if ~isempty(temp)
+        enodes(temp(1),:) = ([nbrnode(vod(i)),nbrnode(vod(i+1)),newnode(spb(i))]);
+    end
+    i = i + 1;
+    clear j j1 j2 temp;
 end
 
 %Addes the 6 new elements.
@@ -132,7 +133,7 @@ imax = 20;
 stoptol = 10e-8 * inrad;
 i = 1;
 tol = stoptol + 10;
-while i <= imax & tol > stoptol
+while i <= imax && tol > stoptol
     M2(2,1) = sum([(x([(nbrnode([1:4])),badnode]))',M(3,1)]);	
     M2(2,2) = sum([(y([(nbrnode([1:4])),badnode]))',M(3,2)]);
     M2(2,3) = sum([(z([(nbrnode([1:4])),badnode]))',M(3,3)]);
@@ -194,12 +195,12 @@ for i = 1:5
     addnode = ([newnode(1),newnode(1),newnode(2),newnode(3),newnode(3)]);
     tmp = nei(nbrnode(spn(i)),:);
     ij = find(tmp == badnode);
-% TCM 04/09/2007 -- Begin
+    % TCM 04/09/2007 -- Begin
     tmp2 = ([tmp(1:(ij-1)),addnode(i),tmp((ij+1):end)]);
     fem.nei(nbrnode(spn(i)),:) = 0;  %Zero out the list
     fem.nei(nbrnode(spn(i)),1:length(tmp2)) = tmp2; %Fill in the list
     %fem.nei(nbrnode(spn(i)),1:end) = ([tmp(1:(ij-1)),addnode(i),tmp((ij+1):end)]);
-% TCM 04/09/2007 -- End
+    % TCM 04/09/2007 -- End
 end    
 
 %Determine the triqual for the final form to see if has very low quality 
@@ -253,29 +254,27 @@ if ~isempty(poor)
          end
          
          %Spring the new mesh after the line swap.
-         it = 1;
-         while it < 3
-         temp = find(fem1.nei(newnode(1),:) ~= 0);
-         tempnei = fem1.nei(newnode(1),temp);
-         fem1.x(newnode(1)) = mean(fem1.x(tempnei));
-         fem1.y(newnode(1)) = mean(fem1.y(tempnei));
-         fem1.z(newnode(1)) = mean(fem1.z(tempnei));
-         temp = find(fem1.nei(newnode(2),:) ~= 0);
-         tempnei = fem1.nei(newnode(2),temp);
-         fem1.x(newnode(2)) = mean(fem1.x(tempnei));
-         fem1.y(newnode(2)) = mean(fem1.y(tempnei));
-         fem1.z(newnode(2)) = mean(fem1.z(tempnei));
-         temp = find(fem1.nei(newnode(3),:) ~= 0);
-         tempnei = fem1.nei(newnode(3),temp);
-         fem1.x(newnode(3)) = mean(fem1.x(tempnei));
-         fem1.y(newnode(3)) = mean(fem1.y(tempnei));
-         fem1.z(newnode(3)) = mean(fem1.z(tempnei));
-         temp = find(fem1.nei(badnode,:) ~= 0);
-         tempnei = fem1.nei(badnode,temp);
-         fem1.x(badnode) = mean(fem1.x(tempnei));
-         fem1.y(badnode) = mean(fem1.y(tempnei));
-         fem1.z(badnode) = mean(fem1.z(tempnei));
-         it = it + 1;
+         for itt = 1:2
+             temp = find(fem1.nei(newnode(1),:) ~= 0);
+             tempnei = fem1.nei(newnode(1),temp);
+             fem1.x(newnode(1)) = mean(fem1.x(tempnei));
+             fem1.y(newnode(1)) = mean(fem1.y(tempnei));
+             fem1.z(newnode(1)) = mean(fem1.z(tempnei));
+             temp = find(fem1.nei(newnode(2),:) ~= 0);
+             tempnei = fem1.nei(newnode(2),temp);
+             fem1.x(newnode(2)) = mean(fem1.x(tempnei));
+             fem1.y(newnode(2)) = mean(fem1.y(tempnei));
+             fem1.z(newnode(2)) = mean(fem1.z(tempnei));
+             temp = find(fem1.nei(newnode(3),:) ~= 0);
+             tempnei = fem1.nei(newnode(3),temp);
+             fem1.x(newnode(3)) = mean(fem1.x(tempnei));
+             fem1.y(newnode(3)) = mean(fem1.y(tempnei));
+             fem1.z(newnode(3)) = mean(fem1.z(tempnei));
+             temp = find(fem1.nei(badnode,:) ~= 0);
+             tempnei = fem1.nei(badnode,temp);
+             fem1.x(badnode) = mean(fem1.x(tempnei));
+             fem1.y(badnode) = mean(fem1.y(tempnei));
+             fem1.z(badnode) = mean(fem1.z(tempnei));
          end
          
          %Use triqual to determine if the new mesh is better quality.
@@ -314,10 +313,9 @@ if sum(nflag) == 0
 end
 
 % Correct output if invalid elements were created.
-bad = find(fem.ar < 0);
-if ~isempty(bad)
-    fem = patch_update(fem_struct,fem1,jj);
-    good = 6;
+if sum(fem.ar < 0) > 0
+   fem = patch_update(fem_struct,fem1,jj);
+   good = 6;
 end
 
 %Display message if invalid elements where created.
@@ -325,6 +323,8 @@ if good == 6
    disp('The nodally updated mesh contained invalid or badly conditioned');
    disp('elements, therefore the patch was retriangulated which should');
    disp('reduce the connecitivity but is not guaranteed to do so.');
+end
+if sum(fem.ar < 0) > 0
    disp(' ');
    disp('returning original mesh');
    fem = fem_struct;

--- a/utilities/Nodal_Reduce_Matlab_Codes/update11nbr.m
+++ b/utilities/Nodal_Reduce_Matlab_Codes/update11nbr.m
@@ -64,8 +64,7 @@ newnode = nnodes + [1:4];
 newelem = nelems + [1:8];
 badnode = jj;
 nbrnode = nei(jj,1:11);
-[nbrelem,J] = find(enodes == badnode);
-clear J;
+[nbrelem,~] = find(enodes == badnode);
 inrad = max(sqrt((x(nbrnode)-x(badnode)).^2 + (y(nbrnode)-y(badnode)).^2));
 
 %First guess of the new coordinates and bathymetry.
@@ -108,15 +107,17 @@ z(newnode(4)) = Ez;
 %Updates the effected elements. J variables are used to represent which
 %elements are connected each node.
 i = 1;
-while i <= 9;
-j1 = ismember((enodes((nbrelem),:)),(nbrnode(vod(i))));
-j2 = ismember((enodes((nbrelem),:)),(nbrnode(vod(i+1))));
-spb = [1,1,2,2,2,3,4,4,4];
-j = sum([j1,j2],2);
-temp = nbrelem(find (j == 2));
-enodes(temp,:) = ([nbrnode(vod(i)),nbrnode(vod(i+1)),newnode(spb(i))]);
-i = i + 1;
-clear j j1 j2 temp;
+while i <= 9
+    j1 = ismember((enodes((nbrelem),:)),(nbrnode(vod(i))));
+    j2 = ismember((enodes((nbrelem),:)),(nbrnode(vod(i+1))));
+    spb = [1,1,2,2,2,3,4,4,4];
+    j = sum([j1,j2],2);
+    temp = nbrelem(find (j == 2));
+    if ~isempty(temp)
+        enodes(temp,:) = ([nbrnode(vod(i)),nbrnode(vod(i+1)),newnode(spb(i))]);
+    end
+    i = i + 1;
+    clear j j1 j2 temp;
 end
 
 %Addes the 8 new elements.
@@ -140,7 +141,7 @@ i = 1;
 imax = 20;
 stoptol = 10e-8 * inrad;
 tol = stoptol + 10;
-while i <= imax & tol > stoptol
+while i <= imax && tol > stoptol
     M2(2,1) = sum([(x([(nbrnode([1:3])),badnode]))',M(3,1),M(4,1)]);
     M2(2,2) = sum([(y([(nbrnode([1:3])),badnode]))',M(3,2),M(4,2)]);
     M2(2,3) = sum([(z([(nbrnode([1:3])),badnode]))',M(3,3),M(4,3)]);
@@ -196,7 +197,7 @@ for i = 1:5
 	ij = find(tmp == badnode);
     ik = min((find(tmp == 0)) + 1);
     if isempty(ik)  % TCM 08/13/2007 -- Added this check in case ik was empty.
-       ik= size(nei,2)+1;
+       ik = size(nei,2)+1;
     end
     fem.nei(nbrnode(spb(i)),1:ik) = ([tmp(1:(ij-1)),addconn(i+1),addconn(i),tmp((ij+1):(ik-1))]);
 end
@@ -261,34 +262,32 @@ if ~isempty(poor)
          end
          
          %Spring the new mesh after the line swap.
-         it = 1;
-         while it < 3
-         temp = find(fem1.nei(newnode(1),:) ~= 0);
-         tempnei = fem1.nei(newnode(1),temp);
-         fem1.x(newnode(1)) = mean(fem1.x(tempnei));
-         fem1.y(newnode(1)) = mean(fem1.y(tempnei));
-         fem1.z(newnode(1)) = mean(fem1.z(tempnei));
-         temp = find(fem1.nei(newnode(2),:) ~= 0);
-         tempnei = fem1.nei(newnode(2),temp);
-         fem1.x(newnode(2)) = mean(fem1.x(tempnei));
-         fem1.y(newnode(2)) = mean(fem1.y(tempnei));
-         fem1.z(newnode(2)) = mean(fem1.z(tempnei));
-         temp = find(fem1.nei(newnode(3),:) ~= 0);
-         tempnei = fem1.nei(newnode(3),temp);
-         fem1.x(newnode(3)) = mean(fem1.x(tempnei));
-         fem1.y(newnode(3)) = mean(fem1.y(tempnei));
-         fem1.z(newnode(3)) = mean(fem1.z(tempnei));
-         temp = find(fem1.nei(newnode(4),:) ~= 0);
-         tempnei = fem1.nei(newnode(4),temp);
-         fem1.x(newnode(4)) = mean(fem1.x(tempnei));
-         fem1.y(newnode(4)) = mean(fem1.y(tempnei));
-         fem1.z(newnode(4)) = mean(fem1.z(tempnei));
-         temp = find(fem1.nei(badnode,:) ~= 0);
-         tempnei = fem1.nei(badnode,temp);
-         fem1.x(badnode) = mean(fem1.x(tempnei));
-         fem1.y(badnode) = mean(fem1.y(tempnei));
-         fem1.z(badnode) = mean(fem1.z(tempnei));
-         it = it + 1;
+         for itt = 1:2
+             temp = find(fem1.nei(newnode(1),:) ~= 0);
+             tempnei = fem1.nei(newnode(1),temp);
+             fem1.x(newnode(1)) = mean(fem1.x(tempnei));
+             fem1.y(newnode(1)) = mean(fem1.y(tempnei));
+             fem1.z(newnode(1)) = mean(fem1.z(tempnei));
+             temp = find(fem1.nei(newnode(2),:) ~= 0);
+             tempnei = fem1.nei(newnode(2),temp);
+             fem1.x(newnode(2)) = mean(fem1.x(tempnei));
+             fem1.y(newnode(2)) = mean(fem1.y(tempnei));
+             fem1.z(newnode(2)) = mean(fem1.z(tempnei));
+             temp = find(fem1.nei(newnode(3),:) ~= 0);
+             tempnei = fem1.nei(newnode(3),temp);
+             fem1.x(newnode(3)) = mean(fem1.x(tempnei));
+             fem1.y(newnode(3)) = mean(fem1.y(tempnei));
+             fem1.z(newnode(3)) = mean(fem1.z(tempnei));
+             temp = find(fem1.nei(newnode(4),:) ~= 0);
+             tempnei = fem1.nei(newnode(4),temp);
+             fem1.x(newnode(4)) = mean(fem1.x(tempnei));
+             fem1.y(newnode(4)) = mean(fem1.y(tempnei));
+             fem1.z(newnode(4)) = mean(fem1.z(tempnei));
+             temp = find(fem1.nei(badnode,:) ~= 0);
+             tempnei = fem1.nei(badnode,temp);
+             fem1.x(badnode) = mean(fem1.x(tempnei));
+             fem1.y(badnode) = mean(fem1.y(tempnei));
+             fem1.z(badnode) = mean(fem1.z(tempnei));
          end
          
          %Use triqual to determine if the new mesh is better quality.

--- a/utilities/Nodal_Reduce_Matlab_Codes/update1320nbr.m
+++ b/utilities/Nodal_Reduce_Matlab_Codes/update1320nbr.m
@@ -52,9 +52,8 @@ enodes = fem_struct.e;
 %Adds new nodes,determines connectivity, and labels the bad node, 
 %neighboring nodesm and neighboring elements.
 badnode = jj;
-[nbrelem,J] = find(enodes == badnode);
+[nbrelem,~] = find(enodes == badnode);
 [nnodes,trnc] = size(nei);
-nelems = size(enodes,1);
 temp1 = sum(ismember(nei(jj,:),0));
 nc = trnc - temp1;
 nbrnode = nei(badnode,1:nc);
@@ -99,12 +98,19 @@ testang(6) = sum([ang([spb(6):nc])]);
 
 %Test to make sure no node is trying to cover more than half of the 
 %circle.
-testr = 1;
-while testang > 180 & testr ~=0
-    hightmp = find(testang > 180);
-    spb(vod(hightemp + 1)) = spb(vod(hightemp + 1)) - 1;
+test = find(testang > 180);
+while ~isempty(test)
+    hightemp = find(testang > 180);
+    hhtempplus = hightemp + 1;
+    if hhtempplus == 7; break; end
+    spb(vod(hhtempplus)) = spb(vod(hhtempplus)) - 1;
+    testang(1) = sum([ang([spb(1):(spb(2)-1)])]);
+    testang(2) = sum([ang([spb(2):(spb(3)-1)])]);
+    testang(3) = sum([ang([spb(3):(spb(4)-1)])]);
+    testang(4) = sum([ang([spb(4):(spb(5)-1)])]);
+    testang(5) = sum([ang([spb(5):(spb(6)-1)])]);
+    testang(6) = sum([ang([spb(6):nc])]);
     test = find(testang > 180);
-	[testr,testc] = size(test);
 end    
 
 %First guess of the new coordinates and bathymetry.
@@ -203,7 +209,7 @@ stoptol = 10e-8 * inrad;
 tol = stoptol + 10;
 i = 1;
 imax = 20;
-while i <= imax & tol > stoptol
+while i <= imax && tol > stoptol
     M2(7,1) = sum([M(2,1),M(1,1),M(3,1),M(5,1),M(4,1),M(6,1)]);
     M2(7,2) = sum([M(2,2),M(1,2),M(3,2),M(5,2),M(4,2),M(6,2)]);
     M2(7,3) = sum([M(2,3),M(1,3),M(3,3),M(5,3),M(4,3),M(6,3)]);
@@ -266,7 +272,7 @@ while i <= imax & tol > stoptol
     
 	tol = max(sqrt((M2(:,1)-M(:,1)).^2 + (M2(:,2)-M(:,2)).^2));
     
-    M = M2;;
+    M = M2;
     x([([newnode(1:6)]),badnode]) = ([M(:,1)]);
     y([([newnode(1:6)]),badnode]) = ([M(:,2)]);
     z([([newnode(1:6)]),badnode]) = ([M(:,3)]);

--- a/utilities/Nodal_Reduce_Matlab_Codes/update8nbr.m
+++ b/utilities/Nodal_Reduce_Matlab_Codes/update8nbr.m
@@ -60,8 +60,7 @@ neweln = nelems+[1,2]; %These are the new element numbers being added
 badndn = jj; % This is the bad node number
 extndn = nei(jj,1:8); % These are the neighbor nodes of badndn listed in a ccw manner
 
-[nbrelems,J] = find(enodes == badndn); %These are the elements connected to the bad node
-clear J
+[nbrelems,~] = find(enodes == badndn); %These are the elements connected to the bad node
 
 % Finds which set of nodes would be best to add more connectors to.
 for i = 1:8
@@ -92,15 +91,14 @@ y([badndn,newndn]) = ybar;
 z([badndn,newndn]) = zbar;
 
 % Update the effected Elements that need to be updated
-[updelem,J] = find(enodes(nbrelems,:) == extndn(vod(spb+5)) | enodes(nbrelems,:) == extndn(vod(spb+7)));
-clear J
-[updelem2,J] = find(enodes(nbrelems(updelem),:) == badndn);
+[updelem,~] = find(enodes(nbrelems,:) == extndn(vod(spb+5)) | enodes(nbrelems,:) == extndn(vod(spb+7)));
+[updelem2,~] = find(enodes(nbrelems(updelem),:) == badndn);
 k = find(enodes(nbrelems(updelem),:) == badndn);
 temp = enodes(nbrelems(updelem),:);
 temp(k) = newndn;
 enodes(nbrelems(updelem),:) = temp;
 
-clear temp J k
+clear temp k
 
 % Adds the Two New Elements
 enodes(neweln(1),:) = [badndn,newndn,extndn(spb)];
@@ -111,7 +109,7 @@ imax = 20;
 stoptol = 10e-7;
 i = 1;
 tol = stoptol+10;
-while i <= imax & tol > stoptol
+while i <= imax && tol > stoptol
     Mx = [sum(y([extndn(vod(spb:spn)),newndn])),sum(y([extndn(vod(spn:spn+4)),badndn]))];
     My = [sum(x([extndn(vod(spb:spn)),newndn])),sum(x([extndn(vod(spn:spn+4)),badndn]))];
     Mz = [sum(z([extndn(vod(spb:spn)),newndn])),sum(z([extndn(vod(spn:spn+4)),badndn]))];

--- a/utilities/Nodal_Reduce_Matlab_Codes/update9nbr.m
+++ b/utilities/Nodal_Reduce_Matlab_Codes/update9nbr.m
@@ -62,8 +62,7 @@ badndn = jj; % This is the bad node number
 extndn = nei(jj,1:9); % These are the neighbor nodes of badndn listed in a ccw manner
 
 % Find all the elements connected to badndn
-[nbrelems,J] = find(enodes == badndn);
-clear J
+[nbrelems,~] = find(enodes == badndn);
 %ortriqul = triqual(fem_struct);
 %ortriqulmin = min(ortriqul(nbrelems))
 
@@ -126,7 +125,7 @@ imax = 20;
 stoptol = 10e-7;
 i = 1;
 tol = stoptol+10;
-while i <= imax & tol > stoptol
+while i <= imax && tol > stoptol
     Mx = [sum(y([extndn(vod(spb:spn)),badndn,newndn])),...
             sum(y([extndn(vod(spn:spn+3)),badndn,newndn])),...
             sum(y([extndn(vod(spn+3:spn+6)),badndn,newndn]))];
@@ -241,24 +240,22 @@ if ~isempty(poor)
          
          
          %Spring the new mesh after the line swap.
-         it = 1;
-         while it < 3
-         temp = find(fem1.nei(newndn(1),:) ~= 0);
-         tempnei = fem1.nei(newndn(1),temp);
-         fem1.x(newndn(1)) = mean(fem1.x(tempnei));
-         fem1.y(newndn(1)) = mean(fem1.y(tempnei));
-         fem1.z(newndn(1)) = mean(fem1.z(tempnei));
-         temp = find(fem1.nei(newndn(2),:) ~= 0);
-         tempnei = fem1.nei(newndn(2),temp);
-         fem1.x(newndn(2)) = mean(fem1.x(tempnei));
-         fem1.y(newndn(2)) = mean(fem1.y(tempnei));
-         fem1.z(newndn(2)) = mean(fem1.z(tempnei));
-         temp = find(fem1.nei(badndn,:) ~= 0);
-         tempnei = fem1.nei(badndn,temp);
-         fem1.x(badndn) = mean(fem1.x(tempnei));
-         fem1.y(badndn) = mean(fem1.y(tempnei));
-         fem1.z(badndn) = mean(fem1.z(tempnei));
-         it = it + 1;
+         for itt = 1:2
+             temp = find(fem1.nei(newndn(1),:) ~= 0);
+             tempnei = fem1.nei(newndn(1),temp);
+             fem1.x(newndn(1)) = mean(fem1.x(tempnei));
+             fem1.y(newndn(1)) = mean(fem1.y(tempnei));
+             fem1.z(newndn(1)) = mean(fem1.z(tempnei));
+             temp = find(fem1.nei(newndn(2),:) ~= 0);
+             tempnei = fem1.nei(newndn(2),temp);
+             fem1.x(newndn(2)) = mean(fem1.x(tempnei));
+             fem1.y(newndn(2)) = mean(fem1.y(tempnei));
+             fem1.z(newndn(2)) = mean(fem1.z(tempnei));
+             temp = find(fem1.nei(badndn,:) ~= 0);
+             tempnei = fem1.nei(badndn,temp);
+             fem1.x(badndn) = mean(fem1.x(tempnei));
+             fem1.y(badndn) = mean(fem1.y(tempnei));
+             fem1.z(badndn) = mean(fem1.z(tempnei));
          end
 
          %Use triqual to determine if the new mesh is better quality.

--- a/utilities/my_interpm.m
+++ b/utilities/my_interpm.m
@@ -1,0 +1,55 @@
+function [latout,lonout] = my_interpm(lat,lon,maxdiff)
+% This function  fills in any gaps in latitude (lat) or longitude (lon) data vectors 
+% that are greater than a defined tolerance maxdiff apart in either dimension.
+% lat and lon should be row vectors.
+%
+% latout and lonout are the new latitude and longitude data vectors, in which any gaps
+% larger than maxdiff in the original vectors have been filled with additional points.
+%
+% by Jindong Wang on March 1, 2018
+%
+if isrow(lat)
+    lat=lat';
+end
+if isrow(lon)
+    lon=lon';
+end
+ny=size(lat,1);
+nx=size(lon,1);
+if nx~=ny || nx<2 || ny<2 || maxdiff<10^-8
+    error('Error: Wrong input!');
+end
+
+dlat=abs(lat(2:end)-lat(1:end-1));
+dlon=abs(lon(2:end)-lon(1:end-1));
+nin=ceil(max([dlat,dlon],[],2)/maxdiff)-1;
+sumnin=sum(nin,'omitnan');
+if sumnin==0
+    disp('No incertion needed.');
+    latout=lat;
+    lonout=lon;
+    return
+end
+nout=sumnin+nx;
+latout=nan(nout,1);
+lonout=nan(nout,1);
+
+n=1;
+for i=1:nx-1;
+    ni=nin(i);
+    if ni==0 || isnan(ni)
+        latout(n)=lat(i);
+        lonout(n)=lon(i);
+        nstep=1;
+    else
+        ilat=linspace(lat(i),lat(i+1),ni+2);
+        ilon=linspace(lon(i),lon(i+1),ni+2);
+        latout(n:n+ni)=ilat(1:ni+1);
+        lonout(n:n+ni)=ilon(1:ni+1);
+        nstep=ni+1;
+    end
+    n=n+nstep;
+end
+latout(end)=lat(end);
+lonout(end)=lon(end);
+        

--- a/utilities/setProj.m
+++ b/utilities/setProj.m
@@ -1,9 +1,15 @@
-function [del] = setProj(obj,proj,projtype)
-    %del = setProj(obj,proj,projtype)
+function [del,obj] = setProj(obj,proj,projtype,insert)
+    % [del,obj] = setProj(obj,proj,projtype)
     % kjr generic function to parse projected space options
     % returns del flag to delete overlapping elements when plotting
     % global models.
+    % if insert = 1, then automatically insert the global m_proj variables
+    % into the msh obj. insert is 0 by default. 
 
+    if nargin < 4
+        insert = 0;
+    end
+    
     % process bounds of mesh
     lon_mi = min(obj.p(:,1)); lon_ma = max(obj.p(:,1));
     lat_mi = min(obj.p(:,2)); lat_ma = max(obj.p(:,2));
@@ -52,13 +58,13 @@ function [del] = setProj(obj,proj,projtype)
                 % center Antarctica
                 m_proj(projtype,'lat',-90,...
                       'long',0.5*(lon_mi+lon_ma),...
-                      'radius',lat_ma+90);
+                      'radius',lat_ma+90,'rot',rot);
             else
                 % center Arctic
                 lat_mi = max(-88.0001,lat_mi);
                 m_proj(projtype,'lat',90,...
                       'long',0.5*(lon_mi+lon_ma),...
-                      'radius',90-lat_mi,'rot',180);
+                      'radius',90-lat_mi,'rot',rot);
             end
             m_proj('get') ;
         elseif  ~isempty(regexp(projtype,'ort')) || ...
@@ -88,5 +94,11 @@ function [del] = setProj(obj,proj,projtype)
                             'lat',[lat_mi lat_ma]) ;
             m_proj('get') ;
         end
+    end
+    if insert
+        global MAP_PROJECTION MAP_COORDS MAP_VAR_LIST
+        obj.proj   = MAP_PROJECTION ; 
+        obj.coord  = MAP_COORDS ; 
+        obj.mapvar = MAP_VAR_LIST ; 
     end
 end


### PR DESCRIPTION
Major change to allow msh plus to correctly preserve weir triangulation and carry over the nodestrings
- I put the collapse thin triangles call inside clean which now comes after delete bad boundary elements
- I let the clean also handle the smoothing so I took this out of the plus
- Clean also handles the iterations if the quality becomes negative after smoothing so no longer need the while loop in msh.plus
- setProj was copied from dev. This allows one to call setProj to add the desired projection into the msh class
- Also reformatted dpoly to improve the memory management (the inpoly is now also subsetted).