### PR TITLE
cleaning up edgefx, smooth_outer and WrapperForKsearch

### DIFF
--- a/@edgefx/private/WrapperForKsearch.m
+++ b/@edgefx/private/WrapperForKsearch.m
@@ -17,12 +17,7 @@ dataset(isnan(dataset(:,1)),:) = [];
 anno = ann(dataset'); 
 idx = ksearch(anno, testset',k,0); 
 idx = idx'; 
-%datax = dataset(1,:)';
-%datay = dataset(2,:)';
-%testx = repmat(testset(1,:)',1,k);
-%testy = repmat(testset(2,:)',1,k);
-%dst = sqrt((testx-datax(idx)).^2 + (testy-datay(idx)).^2);
-anno = close(anno); 
+close(anno); 
 
 % The vector of long lat pairs
 dst = zeros(length(testset),k);

--- a/@meshgen/private/smooth_outer.m
+++ b/@meshgen/private/smooth_outer.m
@@ -20,31 +20,21 @@
             hh_t = efs{bn}.F(x,y);
             % mask non-square component
             nonsq = inpoly([x(:),y(:)],efs{bn}.boubox(1:end-1,:)) ; 
-            hold=hh_m ; % copy it
+            h_old = hh_m ; % copy it
             hh_t(~nonsq)=NaN; % mask it
             hh_m(inx,iny) = hh_t; % put all of it in (w/ NaN)
-            hh_m(isnan(hh_m))=hold(isnan(hh_m)); % replace NaN with old
+            hh_m(isnan(hh_m))=h_old(isnan(hh_m)); % replace NaN with old
         end
         if all(found == 0); continue; end
         disp(['Relaxing the gradient of #' num2str(ii) ' outer edgefx ' ...
               'using #' num2str(find(found)) ' inner edgefxs']);
-        hfun = zeros(numel(efs{ii}.F.Values),1);
-        [~,yg] = ndgrid(efs{ii}.F.GridVectors{1},efs{ii}.F.GridVectors{2});
-        % kjr Oct 2018 already in planar meters!
-        % hh_m = ConvertToPlanarMetres(xg,yg,hh_m) ; 
-        nn = 0;
-        for ipos = 1 : efs{ii}.nx
-            for jpos = 1 : efs{ii}.ny
-                nn = nn + 1;
-                hfun(nn,1) = hh_m(ipos,jpos);
-            end
-        end
+        hfun = reshape(hh_m',[numel(hh_m),1]); 
+        [xg,yg] = ndgrid(efs{ii}.F.GridVectors{1},efs{ii}.F.GridVectors{2});
         % kjr  Oct 2018 consistent with default application of gradient limiting!
         dx = efs{ii}.h0*cosd(yg(1,:));
         dy = efs{ii}.h0;
         
         % make g a function of space
-        [xg,yg] = CreateStructGrid(efs{ii});
         dmy     = xg*0 ;
         for param = efs{ii}.g'
             if numel(param)==1 && param~=0
@@ -61,24 +51,11 @@
                 dmy( limidx ) = lim;
             end
         end
-
-        nn = 0;
-        fdfdx = zeros(size(hh_m,1)*size(hh_m,2),1);
-        for ipos = 1 : efs{ii}.nx
-            for jpos = 1 :efs{ii}.ny
-                nn = nn + 1;
-                fdfdx(nn,1) = dmy(ipos,jpos);
-            end
-        end
-
-        dmy    = [] ; 
-        xg     = [] ; 
-        yg     = [] ; 
-        limidx = [] ;
+        fdfdx = reshape(dmy',[numel(dmy),1]); 
+        clearvars dmy limidx xg yg; 
 
         [hfun,flag] = limgradStruct(efs{ii}.ny,dx,dy,hfun,...
           fdfdx,sqrt(length(hfun)));
-      
      
         if flag == 1
             disp('Gradient relaxing converged!');
@@ -87,14 +64,8 @@
                 'please check your edge functions']);
         end
         % reshape it back
-        nn = 0;
-        for ipos = 1 : efs{ii}.nx
-            for jpos = 1 : efs{ii}.ny
-                nn = nn+1;
-                hh_m(ipos,jpos) = hfun(nn);
-            end
-        end
-        %hh_m = ConvertToWGS84(yg,hh_m) ; 
+        hh_m = reshape(hfun,efs{ii}.ny,[])';
+        clearvars hfun fdfdx
         % Save it back into the interpolant
         efs{ii}.F.Values = hh_m;
     end

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -1704,8 +1704,7 @@ classdef msh
 
                 disp('Forming outer boundary for inset...')
                 try
-                    [cell1,~,max_index] = extdom_polygon(extdom_edges2(t1,p1),p1,-1,0);
-                    bigInset=cell1{max_index};
+                    [cell1] = extdom_polygon(extdom_edges2(t1,p1),p1,-1,0);
                     poly_vec1 = cell2mat(cell1');
                     [edges1] = Get_poly_edges(poly_vec1);
                 catch
@@ -1714,27 +1713,21 @@ classdef msh
 
                 % Delete the region in the global mesh that is in the
                 % intersection with inset.
-                disp('Calculating intersection...');
-                [x3,y3] = polybool('intersection',...
-                    poly_vec1(:,1),poly_vec1(:,2),poly_vec2(:,1),poly_vec2(:,2));
-                if ~isempty(x3)
-                    poly_vec3 = [x3,y3]; poly_vec3(end+1,:) = NaN;
-                    [edges3]  = Get_poly_edges(poly_vec3);
-                    in1 = inpoly(p2(t2(:,1),:),poly_vec3,edges3);
-                    in2 = inpoly(p2(t2(:,2),:),poly_vec3,edges3);
-                    in3 = inpoly(p2(t2(:,3),:),poly_vec3,edges3);
-                    t2(in1 & in2 & in3,:) = [];
-                    % We need to delete straggling elements that are
-                    % generated through the above deletion step
-                    pruned2 = msh() ; pruned2.p = p2; pruned2.t = t2;
-                    pruned2 = Make_Mesh_Boundaries_Traversable(pruned2,0.01,1);
-                    t2 = pruned2.t; p2 = pruned2.p;                    
-                    % get new poly_vec2
-                    if strcmp(type,'arb')
-                        cell2 = extdom_polygon(extdom_edges2(t2,p2),p2,-1,0);
-                        poly_vec2 = cell2mat(cell2');
-                        [edges2] = Get_poly_edges(poly_vec2);
-                    end
+                disp('Deleting intersection...');
+                in1 = inpoly(p2(t2(:,1),:),poly_vec1,edges1);
+                in2 = inpoly(p2(t2(:,2),:),poly_vec1,edges1);
+                in3 = inpoly(p2(t2(:,3),:),poly_vec1,edges1);
+                t2(in1 & in2 & in3,:) = [];
+                % We need to delete straggling elements that are
+                % generated through the above deletion step
+                pruned2 = msh() ; pruned2.p = p2; pruned2.t = t2;
+                pruned2 = Make_Mesh_Boundaries_Traversable(pruned2,0.01,1);
+                t2 = pruned2.t; p2 = pruned2.p;
+                % get new poly_vec2
+                if strcmp(type,'arb')
+                    cell2 = extdom_polygon(extdom_edges2(t2,p2),p2,-1,0);
+                    poly_vec2 = cell2mat(cell2');
+                    [edges2] = Get_poly_edges(poly_vec2);
                 end
 
                 disp('Merging...')
@@ -1748,7 +1741,6 @@ classdef msh
 
                 % Prune triangles outside both domains.
                 disp('Pruning...')
-
                 for ii = 1:2
                     % The loop makes sure to remove only small connectivity for the boundaries
                     if ii == 2
@@ -1772,8 +1764,8 @@ classdef msh
                     in2 = inpoly(pmid,poly_vec2,edges2);
 
                     %in3 is inside the intersection
-                    if strcmp(type,'arb') && exist('poly_vec3','var')
-                        in3 = inpoly(pmid,poly_vec3,edges3);
+                    if strcmp(type,'arb')
+                        in3 = inpoly(pmid,poly_vec1,edges1);
                     else
                         in3 = false(size(in1)); 
                     end

--- a/utilities/m_triplot.m
+++ b/utilities/m_triplot.m
@@ -10,10 +10,12 @@ if isempty(MAP_PROJECTION)
   disp('No Map Projection initialized - call M_PROJ first!');
   return;
 end
-
+bcol=[.8,.9,1];
 [X,Y]=m_ll2xy(long,lat,'clip','on');  
 
-hold on; triplot(tri,X,Y,'k'); 
+hold on; trimesh(tri,X,Y,0*X,'facecolor',bcol,'edgecolor','k');
+view(2)
+%triplot(tri,X,Y,'k','facecolor',bcol); 
 
 %m_coast('patch','red') ; 
 


### PR DESCRIPTION
In edgefx:
- cleaning up the channel function computation
- changing the max_el_ns to be defined in terms of obj.h0 distance from the shoreline
- adding catches for nans in hh_m
- adding the improved shelton et al (1998) calculation for rossby radius near equator and adding an option to compute the first-baroclinic mode (instead of the barotropic mode)

In others:
- In smooth_outer using the concise way to reshape the vector that we pass to the limgradstruct
- in m_triplot add background color like in simpplot so you can see if there are one element holes in the mesh
- deleting comments in WrapperForKsearch