### PR TITLE
cleaning up

### DIFF
--- a/@msh/private/readfort15.m
+++ b/@msh/private/readfort15.m
@@ -119,7 +119,7 @@ token = readlinetoken( fid ) ;
 f15dat.reftim = str2num( token ) ; 
 
 % WTIMINC
-if f15dat.nws > 0
+if f15dat.nws ~= 0
    f15dat.wtimnc = readlinevec( fid ) ;
 end
   
@@ -146,7 +146,7 @@ end
 
 % ESLM, ESLC
 f15dat.elsm = [] ;
-if ( f15dat.im <= 2 | f15dat.im == 10 | f15dat.im >= 111111 )
+if ( f15dat.im <= 2 || f15dat.im == 10 || f15dat.im >= 111111 )
     f15dat.elsm = readlinevec( fid ) ; 
 end
 
@@ -159,14 +159,14 @@ f15dat.ntif = readlinescalar( fid ) ;
 % Tidal potential
 for k = 1: f15dat.ntif
     f15dat.tipotag(k).name = fgetl( fid ) ;
-    f15dat.tipspec(k).val =  readlinevec( fid ) ; 
+    f15dat.tipotag(k).val =  readlinevec( fid ) ; 
 end
  
 % NBFR
 f15dat.nbfr = readlinescalar( fid ) ; 
 for k = 1: f15dat.nbfr
     f15dat.bountag(k).name = fgetl( fid ) ; 
-    f15dat.bounspec(k).val = readlinevec( fid ) ; 
+    f15dat.bountag(k).val = readlinevec( fid ) ; 
 end
 
 % Open boudnary harmonic forcing  
@@ -176,9 +176,7 @@ for k = 1: f15dat.nbfr
     nvd = opedat.neta ; 
     
     val = fscanf(fid, '%f %f \n', [2 nvd] ) ; 
-    
-    %len = size(val) 
-    % val = reshape( val, 2, len/2 ) ; 
+     
     f15dat.opeemoefa(k).val = val' ; 
 end
 

--- a/@msh/private/readfort15.m
+++ b/@msh/private/readfort15.m
@@ -146,7 +146,7 @@ end
 
 % ESLM, ESLC
 f15dat.elsm = [] ;
-if ( f15dat.im <= 2 || f15dat.im == 10 || f15dat.im >= 111111 )
+if ( f15dat.im <= 2 | f15dat.im == 10 | f15dat.im >= 111111 )
     f15dat.elsm = readlinevec( fid ) ; 
 end
 
@@ -158,25 +158,31 @@ f15dat.ntif = readlinescalar( fid ) ;
 
 % Tidal potential
 for k = 1: f15dat.ntif
-    f15dat.tipotag(k).name = fgetl( fid ) ;
+    ll = fgetl(fid);
+    ll(strfind(ll,'!'):end) = [];
+    f15dat.tipotag(k).name = strtrim(ll);
     f15dat.tipotag(k).val =  readlinevec( fid ) ; 
 end
  
 % NBFR
 f15dat.nbfr = readlinescalar( fid ) ; 
 for k = 1: f15dat.nbfr
-    f15dat.bountag(k).name = fgetl( fid ) ; 
+    ll = fgetl(fid);
+    ll(strfind(ll,'!'):end) = [];
+    f15dat.bountag(k).name = strtrim(ll);
     f15dat.bountag(k).val = readlinevec( fid ) ; 
 end
 
-% Open boudnary harmonic forcing  
+% Open boundary harmonic forcing  
 for k = 1: f15dat.nbfr
-    f15dat.opealpha(k).name = fgetl( fid ) ; 
+    ll = fgetl(fid);
+    ll(strfind(ll,'!'):end) = [];
+    f15dat.opealpha(k).name = strtrim(ll); 
     
     nvd = opedat.neta ; 
     
     val = fscanf(fid, '%f %f \n', [2 nvd] ) ; 
-     
+    
     f15dat.opeemoefa(k).val = val' ; 
 end
 

--- a/@msh/private/writefort15.m
+++ b/@msh/private/writefort15.m
@@ -303,6 +303,20 @@ for k = 1: f15dat.nextraline
     fprintf( fid, '%s\n', f15dat.extraline(k).msg ) ;
 end
 
+% If 
+if find(strcmp(fieldnames(f15dat),'controllist'),1)
+for k = 1: length(f15dat.controllist)
+    fprintf( fid, '! -- Begin %s Control Namelist -- \n', f15dat.controllist(k).type ) ;
+    fprintf( fid, '&%sControl\n', f15dat.controllist(k).type ) ;
+    for m = 1:length(f15dat.controllist(k).var)
+        fprintf( fid, '%s = %s,\n',f15dat.controllist(k).var(m).name,...
+                 f15dat.controllist(k).var(m).val) ;
+    end
+    fprintf( fid, '/\n') ;
+    fprintf( fid, '! -- End %s Control Namelist -- \n', f15dat.controllist(k).type ) ;
+end
+end
+
 fclose(fid) ;
  
 end

--- a/utilities/ExtractSubDomain.m
+++ b/utilities/ExtractSubDomain.m
@@ -1,4 +1,5 @@
 function [obj,ind] = ExtractSubDomain(obj,bou,keep_inverse)
+% [obj,ind] = ExtractSubDomain(obj,bou,keep_inverse)
 p = obj.p; t = obj.t; 
 if nargin == 1 || (nargin == 3 && isempty(bou))
     plot(p(:,1),p(:,2),'k.');

--- a/utilities/Make_f15.m
+++ b/utilities/Make_f15.m
@@ -179,6 +179,17 @@ if isempty(obj.f15)
     f15dat.extraline(9).msg = 'name@instit.edu';
     f15dat.extraline(10).msg = '';
     
+    % control lists
+    f15dat.controllist(1).type = 'met';
+    f15dat.controllist(1).var(1).name = 'WindDragLimit';
+    f15dat.controllist(1).var(1).val = 0.0025;
+    f15dat.controllist(1).var(2).name = 'DragLawString';
+    f15dat.controllist(1).var(2).val = 'default'; 
+    f15dat.controllist(1).var(3).name = 'outputWindDrag';
+    f15dat.controllist(1).var(3).val = 'F'; 
+    f15dat.controllist(1).var(4).name = 'invertedBarometerOnElevationBoundary';
+    f15dat.controllist(1).var(4).val = 'F'; 
+    
     % Put into the msh class
     obj.f15 = f15dat;
 end
@@ -262,6 +273,9 @@ end
 % Tidal potential and harmonic analysis stuff
 if ~isempty(const)
     % Get the tidal factors etc based on ts and te 
+    if ischar(const)
+        const = {const};
+    end
     obj = tide_fac(obj,ts,te,const);
     
     % Harmonic analysis stuff (copy in tidal potential)

--- a/utilities/collapse_thin_triangles.m
+++ b/utilities/collapse_thin_triangles.m
@@ -11,7 +11,7 @@ if nargin < 3
 end
 tq = gettrimeshquan(p,t);
 tqm = tq.qm;
-kount=1;
+kount = 0;
 while any(tqm < minqm)
     
     id = find(tqm < minqm); % queue


### PR DESCRIPTION
- remove redundancy from msh.plus
- add the matche' plus option to signal that we want to try and extract portion of obj2 which overlapps which obj1.
- add help line to ExtractSubDomain
- make count start at 0 for collapse_thin_triangles
- change make_mesh_boundaries_traversable to use the non-projected coordinates to determine area so as not to depend on the projection in the "global" variables being used.  takes the proj argument which is default 1 which is used in all the msh routines anyway so no change.  only need to use proj = 0 when trying to run make_mesh_boundaries_traversable directly on unprojected mesh not through clean.