### PR TITLE
adding trim and fixmeshandcarry msh methods

### DIFF
--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -2066,7 +2066,9 @@ classdef msh
             % "fixes" mesh and carries b, bx, by, f13 dat over
             [obj.p,obj.t,pix] = fixmesh(obj.p,obj.t); 
             % move over b, slp, f13
-            obj.b = obj.b(pix); 
+            if ~isempty(obj.b)
+                obj.b = obj.b(pix); 
+            end
             if ~isempty(obj.bx)
                 obj.bx = obj.bx(pix); obj.by = obj.by(pix); 
             end

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -652,9 +652,15 @@ classdef msh
                     userval = obj.f13.userval.Atr(ii).Val;
                     values = userval(2,:);
                     figure;
-                    fastscatter(obj.p(:,1),obj.p(:,2),defval(1)*ones(length(obj.p),1));
-                    hold on
-                    fastscatter(obj.p(userval(1,:),1),obj.p(userval(1,:),2),values');
+                    if proj
+                        m_fastscatter(obj.p(:,1),obj.p(:,2),defval(1)*ones(length(obj.p),1));
+                        hold on
+                        m_fastscatter(obj.p(userval(1,:),1),obj.p(userval(1,:),2),values');
+                    else
+                        fastscatter(obj.p(:,1),obj.p(:,2),defval(1)*ones(length(obj.p),1));
+                        hold on
+                        fastscatter(obj.p(userval(1,:),1),obj.p(userval(1,:),2),values');
+                    end
                     colormap(cmocean('deep'));
                     colorbar;
                 case('transect')
@@ -705,7 +711,11 @@ classdef msh
                         % just take the inf norm
                         values = max(values,[],2);
                         figure;
-                        fastscatter(obj.p(:,1),obj.p(:,2),values);
+                        if proj
+                            m_fastscatter(obj.p(:,1),obj.p(:,2),values);
+                        else
+                            fastscatter(obj.p(:,1),obj.p(:,2),values);
+                        end
                         nouq = length(unique(values));
                         colormap(lansey(nouq));
                         colorbar;
@@ -984,8 +994,8 @@ classdef msh
                 end
             end
             
-            % "fix" mesh
-            [obj.p,obj.t] = fixmesh(obj.p,obj.t);
+            % "fix" mesh and carry
+            obj = fixmeshandcarry(obj);
             
             LT = size(obj.t,1);
             
@@ -1002,7 +1012,7 @@ classdef msh
                     % Delete those boundary elements with quality < opt.db
                     if min(tqbou) >= opt.db; break; end
                     obj.t(bele(tqbou < opt.db),:) = [];
-                    [obj.p,obj.t] = fixmesh(obj.p,obj.t);
+                    obj = fixmeshandcarry(obj);
                 end
                 if opt.nscreen
                     disp(['Deleted ' num2str(LT-size(obj.t,1)) ...
@@ -2024,6 +2034,7 @@ classdef msh
         end
      
         function obj = cat(obj,obj1)
+            % obj = cat(obj,obj1)
             % cat two non-overlapping meshes
             pin = obj1.p; tin = obj1.t;
             [~,d] = ourKNNsearch(pin',pin',2);
@@ -2037,6 +2048,40 @@ classdef msh
             obj.t = [obj.t; tin];
             [obj.p, obj.t] = fixmesh(obj.p,obj.t);
         end
+     
+        function obj = trim(obj,threshold)
+            % obj = trim(obj,threshold)
+            % trim a mesh excluding elevations above the threshold
+            % (given threshold should be positive for overland)
+            if isempty(obj.b) || all(obj.b == 0)
+                error('need bathy on mesh')
+            end
+            bem = max(obj.b(obj.t),[],2);   % only trim when all vertices
+            obj.t(bem < -threshold,:) = []; % of element are above the threshold. 
+            obj = fixmeshandcarry(obj);
+        end
+        
+        function obj = fixmeshandcarry(obj)
+            % obj = fixmeshandcarry(obj);
+            % "fixes" mesh and carries b, bx, by, f13 dat over
+            [obj.p,obj.t,pix] = fixmesh(obj.p,obj.t); 
+            % move over b, slp, f13
+            obj.b = obj.b(pix); 
+            if ~isempty(obj.bx)
+                obj.bx = obj.bx(pix); obj.by = obj.by(pix); 
+            end
+            if ~isempty(obj.f13)
+                for ii = 1:obj.f13.nAttr
+                    ind = obj.f13.userval.Atr(ii).Val(1,:);  
+                    val = obj.f13.userval.Atr(ii).Val(2:end,:);
+                    [~,ia,ib] = intersect(pix,ind);
+                    va = val(:,ib);
+                    obj.f13.userval.Atr(ii).Val = [ia'; va];
+                    obj.f13.userval.Atr(ii).usernumnodes = length(ia);
+                end
+            end
+        end
+            
         
         function obj = CheckElementOrder(obj,proj)
             if nargin == 1

--- a/utilities/Fix_single_connec_edge_elements.m
+++ b/utilities/Fix_single_connec_edge_elements.m
@@ -45,8 +45,10 @@ while it < maxit && ~isempty(del)
     nnei = sum(conn,2);
     del  = find(nnei==1);
     t(del,:) = [];
-    % delete disjoint nodes
-    [p,t] = fixmesh(p,t);
+    % Delete disjoint nodes
+    obj.t = t;
+    obj = fixmeshandcarry(obj);
+    t = obj.t; p = obj.p;
     it = it + 1;
 end
 new = size(t,1);
@@ -55,8 +57,6 @@ if nscreen
     disp(['  ACCEPTED: deleted ' num2str(old-new) ' bad' ...
           ' elements that are connected to a single neighboring element '])
 end
-% Put back into msh obj
-obj.p = p; obj.t = t;
 %EOF
 end
 

--- a/utilities/Make_Mesh_Boundaries_Traversable.m
+++ b/utilities/Make_Mesh_Boundaries_Traversable.m
@@ -63,11 +63,11 @@ if nargin < 4
    proj = 1; 
 end
 
+% fix mesh
+obj = fixmeshandcarry(obj);
+
 % Get p and t out of obj
 p = obj.p; t = obj.t;
-
-% Delete disjoint nodes
-[p,t] = fixmesh(p,t);
 
 % Get boundary edges and nodes
 [etbv,vxe] = extdom_edges2( t, p ) ;
@@ -86,13 +86,17 @@ while numel(etbv) > numel(vxe)
     t = delete_exterior_elements(p,t,dj_cutoff,nscreen,proj);
     
     % Delete disjoint nodes
-    [p,t] = fixmesh(p,t);
+    obj.t = t;
+    obj = fixmeshandcarry(obj);
+    t = obj.t; p = obj.p;
 
     % Delete elements in the interior of the mesh
     t = delete_interior_elements(p,t,nscreen);
      
     % Delete disjoint nodes
-    [p,t] = fixmesh(p,t);
+    obj.t = t;
+    obj = fixmeshandcarry(obj);
+    t = obj.t; p = obj.p;
     
     % Get boundary edges and nodes
     [etbv,vxe] = extdom_edges2( t, p ) ;
@@ -106,8 +110,6 @@ end
 disp('ALERT: finished cleaning up mesh..'); 
 % Turn warnings back on
 warning('on','all')
-% Put back into the msh object
-obj.p = p; obj.t = t;
 end
 % The sub-functions...
 %% Delete elements outside the main mesh depending on dj_cutoff input

--- a/utilities/my_interpm.m
+++ b/utilities/my_interpm.m
@@ -1,4 +1,5 @@
 function [latout,lonout] = my_interpm(lat,lon,maxdiff)
+% [latout,lonout] = my_interpm(lat,lon,maxdiff)
 % This function  fills in any gaps in latitude (lat) or longitude (lon) data vectors 
 % that are greater than a defined tolerance maxdiff apart in either dimension.
 % lat and lon should be row vectors.


### PR DESCRIPTION
- trim method deletes elements above the elevation threshold
- the fixmeshandcarry is a wrapper for fixmesh that also carries over the bathy, slope and f13 attributes
- also I added the proj m_fastscatter options to a couple of the plot cases. 