### PR TITLE
Inverse cfl

### DIFF
--- a/@edgefx/edgefx.m
+++ b/@edgefx/edgefx.m
@@ -905,7 +905,26 @@ classdef edgefx
                     clear cfl dxn
                 end
                 clear u hh_d
+            % Limit CFL if dt < 0, this ensures cfl is sufficiently large for ALE type schemes 
+            else
+                if isempty(feat.Fb); error('No DEM supplied Can''t CFL limit.'); end
+                tmpz    = feat.Fb(xg,yg);
+                grav = 9.807; descfl = 0.50;
+                % limit the minimum depth to 1 m
+                tmpz(tmpz > - 1) = -1;
+                % wavespeed in ocean (second term represents orbital
+                % velocity at 0 degree phase for 1-m amp. wave).
+                u = sqrt(grav*abs(tmpz)) + sqrt(grav./abs(tmpz));
+                disp(['Enforcing timestep of ',num2str(obj.dt),' seconds.']);
+                cr = (abs(obj.dt)*u)./hh_m; % this is your cr
+                dxn = u*abs(obj.dt)/descfl; % assume simulation time step of dt sec and cfl of dcfl;
+                hh_m( cr <= descfl) = dxn( cr <= descfl);   %--in planar metres
+                clear cfl dxn
+                
+                clear u hh_d
+
             end
+
             
             obj.F = griddedInterpolant(xg,yg,hh_m,'linear','nearest');
             

--- a/@edgefx/edgefx.m
+++ b/@edgefx/edgefx.m
@@ -816,7 +816,7 @@ classdef edgefx
             end
             
             % Make sure this is called before releasing memory...
-            if obj.dt == 0
+            if obj.dt(1) == 0
                 % Find min allowable dt based on dis or fs function
                 if any(~cellfun('isempty',strfind(obj.used,'dis')))
                     hh_d = obj.hhd;
@@ -882,47 +882,75 @@ classdef edgefx
             end
             
             % Limit CFL if dt >= 0, dt = 0 finds dt automatically.
-            if obj.dt >= 0
-                if isempty(feat.Fb); error('No DEM supplied Can''t CFL limit.'); end
-                tmpz    = feat.Fb(xg,yg);
-                grav = 9.807; descfl = 0.50;
-                % limit the minimum depth to 1 m
-                tmpz(tmpz > - 1) = -1;
-                % wavespeed in ocean (second term represents orbital
-                % velocity at 0 degree phase for 1-m amp. wave).
-                u = sqrt(grav*abs(tmpz)) + sqrt(grav./abs(tmpz));
-                if obj.dt == 0
-                    hh_d(hh_d < obj.h0) = obj.h0;
-                    obj.dt = min(min(descfl*hh_d./u));
+            if obj.dt(1) >= 0
+                if isempty(feat.Fb)
+                    error('No DEM supplied Can''t CFL limit.')
                 end
-                if isnan(obj.dt)
-                    disp('No timestep enforcement due to no distance function') 
-                else
-                    disp(['Enforcing timestep of ',num2str(obj.dt),' seconds.']);
-                    cfl = (obj.dt*u)./hh_m; % this is your cfl
-                    dxn = u*obj.dt/descfl;      % assume simulation time step of dt sec and cfl of dcfl;
-                    hh_m( cfl > descfl) = dxn( cfl > descfl);   %--in planar metres
-                    clear cfl dxn
-                end
-                clear u hh_d
-            % Limit CFL if dt < 0, this ensures cfl is sufficiently large for ALE type schemes 
-            else
-                if isempty(feat.Fb); error('No DEM supplied Can''t CFL limit.'); end
-                tmpz    = feat.Fb(xg,yg);
-                grav = 9.807; descfl = 0.50;
-                % limit the minimum depth to 1 m
-                tmpz(tmpz > - 1) = -1;
-                % wavespeed in ocean (second term represents orbital
+                % Estimate wavespeed in ocean (second term represents orbital
                 % velocity at 0 degree phase for 1-m amp. wave).
+                tmpz    = feat.Fb(xg,yg);
+                grav = 9.807;
+                % Limit the minimum depth to 1 m (ignore overland)
+                tmpz(tmpz > - 1) = -1;
                 u = sqrt(grav*abs(tmpz)) + sqrt(grav./abs(tmpz));
-                disp(['Enforcing timestep of ',num2str(obj.dt),' seconds.']);
-                cr = (abs(obj.dt)*u)./hh_m; % this is your cr
-                dxn = u*abs(obj.dt)/descfl; % assume simulation time step of dt sec and cfl of dcfl;
-                hh_m( cr <= descfl) = dxn( cr <= descfl);   %--in planar metres
-                clear cfl dxn
                 
-                clear u hh_d
-
+                % Desired timestep to bound edgefx
+                desDt = obj.dt(1);
+                if isnan(desDt)
+                    disp('No timestep enforcement due to no distance function')
+                end
+                
+                % Determine Courant min. and max. bounds  
+                if length(obj.dt) < 2
+                    % default behavior if no bounds are passed
+                    % for explicit type schemes we ensure the maxCr is
+                    % bounded
+                    minCr = eps; % Cannot be zero!!!
+                    maxCr = 0.5;
+                elseif length(obj.dt) == 2
+                    % minimum Courant number bound 
+                    minCr = obj.dt(2); 
+                    maxCr = inf; 
+                elseif length(obj.dt) == 3 
+                    % minimum and maximum Courant bound
+                    minCr = obj.dt(2);
+                    maxCr = obj.dt(3);
+                else
+                    error('Length of dt name-value pair should be <=3')
+                end
+                
+                if minCr > maxCr
+                    error('MinCr is > MaxCr, please switch order in dt name value call')
+                end
+                
+                % Enforcement of Courant bounds in mesh size function
+                fprintf(1, [ ...
+                    'Enforcing timestep of ',num2str(desDt),' seconds ', ...
+                    'with Courant number bounds of ',num2str(minCr),' to ',num2str(maxCr),'\n', ...
+                    ] ) ;
+                
+                % Automatic timestep selection option (for ADCIRC models)
+                if desDt == 0
+                    hh_d(hh_d < obj.h0) = obj.h0;
+                    obj.dt = min(min(minCr*hh_d./u));
+                    desDt  = obj.dt;
+                end
+                
+                Cr = (desDt*u)./hh_m; % Courant number for given desDt for mesh size variations
+                
+                % resolution that meets max. Cr. criteria for desDt
+                dxn_min = u*desDt/maxCr;
+                % resolution that meets min. Cr. criteria for desDt
+                dxn_max = u*desDt/minCr;
+                
+                % resolve min. Cr violations
+                hh_m( Cr <= minCr) = dxn_max( Cr <= minCr); %--in planar metres
+                
+                % resolve max. Cr violations
+                hh_m( Cr > maxCr) = dxn_min( Cr > maxCr);   %--in planar metres
+                
+                clear dxn_min dxn_max Cr
+                clear u hh_d tmpz
             end
 
             

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -2066,7 +2066,9 @@ classdef msh
             % "fixes" mesh and carries b, bx, by, f13 dat over
             [obj.p,obj.t,pix] = fixmesh(obj.p,obj.t); 
             % move over b, slp, f13
-            obj.b = obj.b(pix); 
+            if ~isempty(obj.b)
+                obj.b = obj.b(pix); 
+            end
             if ~isempty(obj.bx)
                 obj.bx = obj.bx(pix); obj.by = obj.by(pix); 
             end

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -652,9 +652,15 @@ classdef msh
                     userval = obj.f13.userval.Atr(ii).Val;
                     values = userval(2,:);
                     figure;
-                    fastscatter(obj.p(:,1),obj.p(:,2),defval(1)*ones(length(obj.p),1));
-                    hold on
-                    fastscatter(obj.p(userval(1,:),1),obj.p(userval(1,:),2),values');
+                    if proj
+                        m_fastscatter(obj.p(:,1),obj.p(:,2),defval(1)*ones(length(obj.p),1));
+                        hold on
+                        m_fastscatter(obj.p(userval(1,:),1),obj.p(userval(1,:),2),values');
+                    else
+                        fastscatter(obj.p(:,1),obj.p(:,2),defval(1)*ones(length(obj.p),1));
+                        hold on
+                        fastscatter(obj.p(userval(1,:),1),obj.p(userval(1,:),2),values');
+                    end
                     colormap(cmocean('deep'));
                     colorbar;
                 case('transect')
@@ -705,7 +711,11 @@ classdef msh
                         % just take the inf norm
                         values = max(values,[],2);
                         figure;
-                        fastscatter(obj.p(:,1),obj.p(:,2),values);
+                        if proj
+                            m_fastscatter(obj.p(:,1),obj.p(:,2),values);
+                        else
+                            fastscatter(obj.p(:,1),obj.p(:,2),values);
+                        end
                         nouq = length(unique(values));
                         colormap(lansey(nouq));
                         colorbar;
@@ -984,8 +994,8 @@ classdef msh
                 end
             end
             
-            % "fix" mesh
-            [obj.p,obj.t] = fixmesh(obj.p,obj.t);
+            % "fix" mesh and carry
+            obj = fixmeshandcarry(obj);
             
             LT = size(obj.t,1);
             
@@ -1002,7 +1012,7 @@ classdef msh
                     % Delete those boundary elements with quality < opt.db
                     if min(tqbou) >= opt.db; break; end
                     obj.t(bele(tqbou < opt.db),:) = [];
-                    [obj.p,obj.t] = fixmesh(obj.p,obj.t);
+                    obj = fixmeshandcarry(obj);
                 end
                 if opt.nscreen
                     disp(['Deleted ' num2str(LT-size(obj.t,1)) ...
@@ -2024,6 +2034,7 @@ classdef msh
         end
      
         function obj = cat(obj,obj1)
+            % obj = cat(obj,obj1)
             % cat two non-overlapping meshes
             pin = obj1.p; tin = obj1.t;
             [~,d] = ourKNNsearch(pin',pin',2);
@@ -2037,6 +2048,40 @@ classdef msh
             obj.t = [obj.t; tin];
             [obj.p, obj.t] = fixmesh(obj.p,obj.t);
         end
+     
+        function obj = trim(obj,threshold)
+            % obj = trim(obj,threshold)
+            % trim a mesh excluding elevations above the threshold
+            % (given threshold should be positive for overland)
+            if isempty(obj.b) || all(obj.b == 0)
+                error('need bathy on mesh')
+            end
+            bem = max(obj.b(obj.t),[],2);   % only trim when all vertices
+            obj.t(bem < -threshold,:) = []; % of element are above the threshold. 
+            obj = fixmeshandcarry(obj);
+        end
+        
+        function obj = fixmeshandcarry(obj)
+            % obj = fixmeshandcarry(obj);
+            % "fixes" mesh and carries b, bx, by, f13 dat over
+            [obj.p,obj.t,pix] = fixmesh(obj.p,obj.t); 
+            % move over b, slp, f13
+            obj.b = obj.b(pix); 
+            if ~isempty(obj.bx)
+                obj.bx = obj.bx(pix); obj.by = obj.by(pix); 
+            end
+            if ~isempty(obj.f13)
+                for ii = 1:obj.f13.nAttr
+                    ind = obj.f13.userval.Atr(ii).Val(1,:);  
+                    val = obj.f13.userval.Atr(ii).Val(2:end,:);
+                    [~,ia,ib] = intersect(pix,ind);
+                    va = val(:,ib);
+                    obj.f13.userval.Atr(ii).Val = [ia'; va];
+                    obj.f13.userval.Atr(ii).usernumnodes = length(ia);
+                end
+            end
+        end
+            
         
         function obj = CheckElementOrder(obj,proj)
             if nargin == 1

--- a/utilities/Fix_single_connec_edge_elements.m
+++ b/utilities/Fix_single_connec_edge_elements.m
@@ -45,8 +45,10 @@ while it < maxit && ~isempty(del)
     nnei = sum(conn,2);
     del  = find(nnei==1);
     t(del,:) = [];
-    % delete disjoint nodes
-    [p,t] = fixmesh(p,t);
+    % Delete disjoint nodes
+    obj.t = t;
+    obj = fixmeshandcarry(obj);
+    t = obj.t; p = obj.p;
     it = it + 1;
 end
 new = size(t,1);
@@ -55,8 +57,6 @@ if nscreen
     disp(['  ACCEPTED: deleted ' num2str(old-new) ' bad' ...
           ' elements that are connected to a single neighboring element '])
 end
-% Put back into msh obj
-obj.p = p; obj.t = t;
 %EOF
 end
 

--- a/utilities/Make_Mesh_Boundaries_Traversable.m
+++ b/utilities/Make_Mesh_Boundaries_Traversable.m
@@ -63,11 +63,11 @@ if nargin < 4
    proj = 1; 
 end
 
+% fix mesh
+obj = fixmeshandcarry(obj);
+
 % Get p and t out of obj
 p = obj.p; t = obj.t;
-
-% Delete disjoint nodes
-[p,t] = fixmesh(p,t);
 
 % Get boundary edges and nodes
 [etbv,vxe] = extdom_edges2( t, p ) ;
@@ -86,13 +86,17 @@ while numel(etbv) > numel(vxe)
     t = delete_exterior_elements(p,t,dj_cutoff,nscreen,proj);
     
     % Delete disjoint nodes
-    [p,t] = fixmesh(p,t);
+    obj.t = t;
+    obj = fixmeshandcarry(obj);
+    t = obj.t; p = obj.p;
 
     % Delete elements in the interior of the mesh
     t = delete_interior_elements(p,t,nscreen);
      
     % Delete disjoint nodes
-    [p,t] = fixmesh(p,t);
+    obj.t = t;
+    obj = fixmeshandcarry(obj);
+    t = obj.t; p = obj.p;
     
     % Get boundary edges and nodes
     [etbv,vxe] = extdom_edges2( t, p ) ;
@@ -106,8 +110,6 @@ end
 disp('ALERT: finished cleaning up mesh..'); 
 % Turn warnings back on
 warning('on','all')
-% Put back into the msh object
-obj.p = p; obj.t = t;
 end
 % The sub-functions...
 %% Delete elements outside the main mesh depending on dj_cutoff input

--- a/utilities/my_interpm.m
+++ b/utilities/my_interpm.m
@@ -1,4 +1,5 @@
 function [latout,lonout] = my_interpm(lat,lon,maxdiff)
+% [latout,lonout] = my_interpm(lat,lon,maxdiff)
 % This function  fills in any gaps in latitude (lat) or longitude (lon) data vectors 
 % that are greater than a defined tolerance maxdiff apart in either dimension.
 % lat and lon should be row vectors.


### PR DESCRIPTION
Initial support for ensuring the Courant number is sufficiently large for models like SCHISM which generally perform better with larger Cr (i.e., > 0.5) based on issue #51 

This edit allows the edgefx class to take a negative value for the dt name value pair. This will make sure the minimum Courant number is 0.50 (by default) in the edgefx. 

Keep in mind this may significantly add new vertices to the problem! 

Still todo: add capabilities in msh.CheckTimestep to split bars analogous behavior to decimating vertices to shrink the Courant number. 