### PR TITLE
allowing for backupdem to replace dem outside of dem bbox

### DIFF
--- a/@geodata/geodata.m
+++ b/@geodata/geodata.m
@@ -306,6 +306,8 @@ classdef geodata
             
             obj = ParseDEM(obj) ;
             
+            
+            
         end
         
         function obj = ParseShoreline(obj)
@@ -556,9 +558,14 @@ classdef geodata
                     clear x y demz
                 else
                     % main interpolant
-                    obj.Fb   = griddedInterpolant({x,y},demz,...
-                        'linear','nearest');
-                    obj.x0y0 = [x(1),y(1)];
+                    if obj.BACKUPdemfile~=0
+                        obj.Fb   = griddedInterpolant({x,y},demz,...
+                            'linear','none'); % no extrapolation (so use Fb2)
+                    else
+                        obj.Fb   = griddedInterpolant({x,y},demz,...
+                            'linear','nearest');
+                        obj.x0y0 = [x(1),y(1)];
+                    end
                     % clear data from memory
                     clear x y demz
                 end

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -871,7 +871,8 @@ classdef msh
             %                         relevant for CA interpolation method).
             %                         default value N=1.
             %
-            %        nan - 'fill' to fill in any NaNs appearing in bathy
+            %        nan - 'fill' to fill in any NaNs everywhere
+            %            -'fillinside' to fill NaNs only in DEM extents
             %
             %   mindepth - ensure the minimum depth is bounded in the
             %                         interpolated region

--- a/@msh/private/GridData.m
+++ b/@msh/private/GridData.m
@@ -30,7 +30,8 @@ function obj = GridData(geodata,obj,varargin)
 %                         relevant for CA interpolation method). 
 %                         default value N=1. 
 %
-%        nan (optional) - 'fill' to fill in any NaNs appearing in bathy
+%        nan (optional) - 'fill' to fill in any NaNs everywhere
+%                        -'fillinside' to fill NaNs only in DEM extents
 %
 %   mindepth (optional) - ensure the minimum depth is bounded in the 
 %                         interpolated region 

--- a/utilities/Calc_f13.m
+++ b/utilities/Calc_f13.m
@@ -11,6 +11,7 @@ function obj = Calc_f13(obj,attribute,varargin)
 %              'Mn' ('mannings_n_at_sea_floor')
 %              'Ss' ('surface_submergence_state')
 %              'Re' ('initial_river_elevation')
+%              'Ad' ('advection_state')
 %
 %            3) then either: 
 %              'inpoly' followed by...
@@ -47,6 +48,9 @@ elseif strcmpi(attribute,'Ss')
 elseif strcmpi(attribute,'Re')
     attrname = 'initial_river_elevation';
     default_val = 0;
+elseif strcmpi(attribute,'Ad')
+    attrname = 'advection_state';
+    default_val = -999;
 else
     error(['Attribute ' attribute ' not currently supported'])
 end


### PR DESCRIPTION
If the bbox of geodata is set to be greater than the extents of the main dem, backupdem can replace those values:
- geodata now does not set obj.x0y0 to that of the main dem if backupdem present
- in edgefx add line to replace nans in main dem with the backupdem (will occur if outside main dem extents)

additional change: modify if statement to handle case of "fl" being a positive scalar to indicate low pass filter.