### PR TITLE
Auto make bc update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 m_map/
 datasets/
 fort.*
+Examples/*.mat
 /*.mat
 !weirs_cell.mat
 !weirs_struct.mat

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -1196,7 +1196,7 @@ classdef msh
                                 error("No DEM info to use 'depth' classification criteria")
                             end
                             if length(varargin) > 2 && ~isempty(varargin{3})
-                                depth_lim = varargin{3};
+                                depth_lim = -varargin{3};
                             end
                         case('both')
                             if isempty(gdat.Fb)
@@ -1206,7 +1206,7 @@ classdef msh
                                 dist_lim = varargin{3};
                             end
                             if length(varargin) > 3 && ~isempty(varargin{4})
-                                depth_lim = varargin{4};
+                                depth_lim = -varargin{4};
                             end
                     end
                     cut_lim = 10;

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -1118,7 +1118,7 @@ classdef msh
         % re-direct makens to make_bc
         function obj = makens(obj,type,varargin)
             % 'makens' is deprecated. Please use 'make_bc'
-            obj = make_bc(obj,type,varargin{1});
+            obj = make_bc(obj,type,varargin);
         end
         
         % make_bc: make boundary conditions
@@ -1168,6 +1168,9 @@ classdef msh
             % 
             if nargin < 2
                 error("Needs type: one of 'auto', 'outer', 'inner', 'delete', or 'weirs'")
+            end
+            if iscell(varargin{1})
+                varargin = varargin{1};
             end
             L = 1e3;
             switch type

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -1164,8 +1164,14 @@ classdef msh
             % varargin{1} (optional): ibtype to set (default = 21)
             %
             % ---------
-            % Please insert 'delete', and 'weirs' help info
+            % 'weirs' - applies weir bcs to all weirs passed in your gdat. 
+            % varargins: 
+            % varargin{1}: geodata class that had crestlines passed. 
             % 
+            % ---------
+            % 'delete' - deletes a user-clicked boundary condition from msh. 
+            % varargins: 
+            % none
             if nargin < 2
                 error("Needs type: one of 'auto', 'outer', 'inner', 'delete', or 'weirs'")
             end
@@ -1281,13 +1287,22 @@ classdef msh
                         if eb_sum > 0
                             % % Consists of both ocean and mainland
                             
-                            % indices of switch between ocean and mainland
+                            % If a boundary segment is composed of both 
+                            % ocean and mainland, then the whole segment is 
+                            % 'cut up' into segments. Special care is 
+                            % taken to ensure the ocean 
+                            % type boundary starts following then by mainland
+                            % etc.
                             Cuts  = find(diff(eb_class_t) ~= 0);
                             
                             % Do not include open boundary that is
                             % smaller than cutlim vertices across
                             rm = false(length(Cuts),1);
-                            if eb_class_t(1); st = 2; else; st = 1; end
+                            if eb_class_t(1)
+                                st = 2; 
+                            else
+                                st = 1;
+                            end
                             for ii = st:2:length(Cuts)
                                 if ii == length(Cuts)
                                     if length(idv) - Cuts(ii) + ...

--- a/Examples/Example_1_NZ.m
+++ b/Examples/Example_1_NZ.m
@@ -27,6 +27,7 @@ mshopts = mshopts.build;
 %% STEP 5: Plot it and write a triangulation fort.14 compliant file to disk.
 % Get out the msh class and put on nodestrings
 m = mshopts.grd;
-m = makens(m,'auto',gdat); % make the nodestring boundary conditions
+m = make_bc(m,'auto',gdat,'distance'); % make the boundary conditions
 plot(m,'bd');
-write(m,'South_Island_NZ');
+% if you want to write into fort.14...
+% write(m,'South_Island_NZ');

--- a/Examples/Example_2_NY.m
+++ b/Examples/Example_2_NY.m
@@ -29,7 +29,7 @@ mshopts = mshopts.build;
 % Get out the msh class and put on bathy and nodestrings
 m = mshopts.grd;
 m = interp(m,gdat,'mindepth',1); % interpolate bathy to the mesh with minimum depth of 1 m
-m = makens(m,'auto',gdat,[],5);  % make the nodestring boundary conditions 
+m = make_bc(m,'auto',gdat,'depth',5);  % make the nodestring boundary conditions 
                                  % with min depth of 5 m on open boundary
 plot(m,'bd'); plot(m,'blog');    % plot triangulation, and bathy on log scale
 write(m,'NY_HR');                % write to ADCIRC compliant ascii file

--- a/Examples/Example_3_ECGC.m
+++ b/Examples/Example_3_ECGC.m
@@ -56,7 +56,7 @@ mshopts = mshopts.build;
 %% Plot and save the msh class object/write to fort.14
 m = mshopts.grd; % get out the msh object
 m = interp(m,{gdat1 gdat2},'mindepth',1); % interpolate bathy to the mesh with minimum depth of 1 m
-m = makens(m,'auto',gdat1);               % make the nodestring boundary conditions
+m = make_bc(m,'auto',gdat1);               % make the nodestring boundary conditions
 plot(m,'bd',1); % plot on native projection with nodestrings
 plot(m,'b',1); % plot bathy on native projection
 save('ECGC_w_NYHR.mat','m'); write(m,'ECGC_w_NYHR');

--- a/Examples/Example_4_PRVI.m
+++ b/Examples/Example_4_PRVI.m
@@ -78,7 +78,7 @@ m = mshopts.grd;
 m = interp(m,gdat,'mindepth',1); % interpolate bathy to the mesh with minimum depth of 1 m
 
 %% Make the nodestrings
-m = makens(m,'auto',gdat{1}); % make the nodestring boundary conditions
+m = make_bc(m,'auto',gdat{1}); % make the nodestring boundary conditions
 
 %% Plot and save the msh class object/write to fort.14
 plot(m,'bd'); % plot triangulation with nodestrings

--- a/Examples/Example_5_JBAY.m
+++ b/Examples/Example_5_JBAY.m
@@ -38,7 +38,7 @@ mshopts = mshopts.build;
 m = mshopts.grd;
 m = interp(m,gdat,'nan','fill','mindepth',1); % interpolate bathy to the 
                 % mesh with fill nan option to make sure corners get values
-m = makens(m,'auto',gdat,[],5); % make the nodestring boundary conditions
+m = make_bc(m,'auto',gdat,'depth',5); % make the nodestring boundary conditions
                            % with depth cutoff for open boundary set to 5 m
 plot(m,'bd'); plot(m,'blog'); % plot triangulation and bathy
 save('JBAY_HR.mat','m')

--- a/Examples/Example_5b_JBAY_w_weirs.m
+++ b/Examples/Example_5b_JBAY_w_weirs.m
@@ -41,9 +41,9 @@ mshopts = mshopts.build;
 m = mshopts.grd;
 
 %% STEP 5: Manually specify open boundaries and weir crest heights
-m = makens(m,'auto',gdat,[],5);       % auto makens
+m = make_bc(m,'auto',gdat,'depth',5); % auto makens
 m.bd = [];                            % reset land boundaries
-m = makens(m,'weirs',gdat,1,[weirs.crestheight]);  % add nodestrings for the weirs
+m = make_bc(m,'weirs',gdat,1,[weirs.crestheight]);  % add nodestrings for the weirs
 
 %% STEP 6: interpolate bathy and plot and save the mesh
 m = interp(m,gdat,'nan','fill','mindepth',1); % interpolate bathy to the 

--- a/Examples/Example_5b_JBAY_w_weirs.m
+++ b/Examples/Example_5b_JBAY_w_weirs.m
@@ -41,9 +41,9 @@ mshopts = mshopts.build;
 m = mshopts.grd;
 
 %% STEP 5: Manually specify open boundaries and weir crest heights
-m = make_bc(m,'auto',gdat,'depth',5); % auto makens
-m.bd = [];                            % reset land boundaries
-m = make_bc(m,'weirs',gdat,1,[weirs.crestheight]);  % add nodestrings for the weirs
+m = make_bc(m,'auto',gdat,'both',[],5); % auto make_bc with depth_lim = 5
+m.bd = [];                              % delete land bcs and replace with weirs below
+m = make_bc(m,'weirs',gdat,1,[weirs.crestheight]);  % add bcs for the weirs
 
 %% STEP 6: interpolate bathy and plot and save the mesh
 m = interp(m,gdat,'nan','fill','mindepth',1); % interpolate bathy to the 

--- a/Examples/Example_6_GBAY.m
+++ b/Examples/Example_6_GBAY.m
@@ -35,6 +35,6 @@ mshopts = mshopts.build;
 %% STEP 5: Plot it and write a triangulation fort.14 compliant file to disk.
 m = mshopts.grd;
 m = interp(m,gdat,'mindepth',1,'nan','fill'); % interpolate bathy to the mesh
-m = makens(m,'auto',gdat); % make the nodestring boundary conditions
+m = make_bc(m,'auto',gdat); % make the nodestring boundary conditions
 plot(m,'bd'); plot(m,'blog'); % plot triangulation and bathy
 write(m,'HoustonShipChannel');

--- a/Tests/TestJBAY.m
+++ b/Tests/TestJBAY.m
@@ -1,5 +1,5 @@
 % Run example 5b to build a mesh around Jbay with the weirs
-run('../Example_5b_JBAY_w_weirs.m')
+run('../Examples/Example_5b_JBAY_w_weirs.m')
 
 ERR_TOL = 0.05;
 ERR2_TOL = 0.01;

--- a/Tests/TestSanity.m
+++ b/Tests/TestSanity.m
@@ -1,6 +1,6 @@
 % Run example 1 to build a mesh around NZ testing various basic functionality 
 % is working!
-run('../Example_1_NZ.m')
+run('../Examples/Example_1_NZ.m')
 
 NP_TOL = 500;
 NT_TOL = 1500;


### PR DESCRIPTION
-Rename msh.makens to msh.make_bc

- Updates to the auto option in the make_bc function. You can now select 'depth', 'distance' or 'both' options for classifying whether a boundary edge is ocean or not.
- 'depth': is an edge below a certain depth (default is 10 m)
- 'distance': is an edge close enough to the shoreline (default is 10*gdat.gridspace)
- 'both [default]: does the edge satisfy both criteria?

examples:

m = make_bc(m,'auto',gdat);
![image](https://user-images.githubusercontent.com/21131934/78193514-58840f00-7440-11ea-8914-02fbfd039086.png)

                                                    
m = make_bc(m,'auto',gdat,'depth',5);
![image](https://user-images.githubusercontent.com/21131934/78193550-69348500-7440-11ea-82e0-117aae149a4e.png)

m = make_bc(m,'auto',gdat,'both',2.5e3/111e3,5);
![image](https://user-images.githubusercontent.com/21131934/78193494-4e621080-7440-11ea-988a-d088c71fd893.png)

Update: I successfully passed the test suite after updating the makens call to be make_bc in the NZ and JBAY weir examples. 