### PR TITLE
support for reading in heavy DEMs

### DIFF
--- a/@geodata/geodata.m
+++ b/@geodata/geodata.m
@@ -526,9 +526,9 @@ classdef geodata
                         mult = (obj.bbox(1,2) - obj.bbox(1,1))/...
                                    (bboxt(1,2) - bboxt(1,1)); 
                         peak_mem = mult*length(I)*length(J)*4/1e9; % in GB assuming single
-                        STRIDE = ceil(sqrt(peak_mem/AVAILABLE_MEMORY));
-                        %DEM_GRIDSPACE = (x(2)-x(1))*111e3; % in meters
-                        %STRIDE = ceil(obj.h0/DEM_GRIDSPACE); % skip # of DEM entires
+                        %STRIDE = ceil(sqrt(peak_mem/AVAILABLE_MEMORY));
+                        DEM_GRIDSPACE = (x(2)-x(1))*111e3; % in meters
+                        STRIDE = ceil(obj.h0/DEM_GRIDSPACE); % skip # of DEM entires
                         if STRIDE > 1
                             warning([' DEM would occupy ',num2str(peak_mem),'GB of RAM.'...
                                      ' DEM will be downsampled to fit in the 4GB RAM ' ...

--- a/@geodata/geodata.m
+++ b/@geodata/geodata.m
@@ -520,12 +520,11 @@ classdef geodata
                     I = [I; It];
                     
                     % At this point, detect the memory footprint of the 
-                    % DEM subset and stop if we know there will be problems. 
+                    % DEM subset and compute the required stride necessary
+                    % to satisfy the memory requirements
                     if nn == 1
-                        mult = 1;
-                        % if loop is 2 assume that we read in twice the 
-                        % size of the first loop
-                        if loop == 2; mult = 2; end
+                        mult = (obj.bbox(1,2) - obj.bbox(1,1))/...
+                                   (bboxt(1,2) - bboxt(1,1)); 
                         peak_mem = mult*length(I)*length(J)*4/1e9; % in GB assuming single
                         STRIDE = ceil(sqrt(peak_mem/AVAILABLE_MEMORY));
                         %DEM_GRIDSPACE = (x(2)-x(1))*111e3; % in meters
@@ -555,8 +554,10 @@ classdef geodata
                     end
                     % grab only the portion that was requested with a
                     % stride
+                    LX = length(It(1:STRIDE:end));
+                    LY = length(J(1:STRIDE:end));
                     demzt = single(ncread(fname,zvn,[It(1) J(1)],...
-                                 [length(It) length(J)],[STRIDE,STRIDE]));
+                                   [LX LY],[STRIDE,STRIDE]));
                     if isempty(demz)
                         demz = demzt;
                     else

--- a/@geodata/geodata.m
+++ b/@geodata/geodata.m
@@ -551,10 +551,10 @@ classdef geodata
                     It = find(x >= bboxt(1,1) & x <= bboxt(1,2));
                     I = [I; It];
                     if EXCESSIVE_MEMORY_ALLOCATED
-                        % read the full thing a stride 
+                        % read the full thing a stride
                         demzt = single(ncread(fname,zvn,...
-                            [1 1],[inf, inf],[STRIDE,STRIDE]));
-                        % grab only the portion that was requested. 
+                            [It(1) J(1)],[length(It) length(J)],[STRIDE,STRIDE]));
+                        % grab only the portion that was requested.
                         
                     else
                         demzt = single(ncread(fname,zvn,...


### PR DESCRIPTION
**Problem**: 
Heavy DEMs memory-wise are often encountered in coastal modeling. Sometimes users may be modeling an area covered by a high resolution DEM (1/9 arc second) that can easily exceed virtual memory. However, the intended minimum mesh resolution is coarser than the native DEM resolution. 

**Solution**
  A solution I am trying is to avoid reading the entire DEM into RAM in the geodata class:
-Instead the DEM is read in at a stride determined by the desired minimum mesh resolutio, the native DEM grid spacing, and the available memory on the machine. This can drastically reduce the memory footprint. 
-I installed warnings that detect when an excessive memory allocation will occur and pause the execution. 

**Current problems**
Does not work with user defined bbox passed to geodata yet. Currently only supports the case when the entire DEM is to be read in without user specified bbox. 
