### PR TITLE
Consistent example format and m_trisurf additional option

### DIFF
--- a/Examples/Example_1_NZ.m
+++ b/Examples/Example_1_NZ.m
@@ -1,8 +1,10 @@
 % Example_1_NZ: Mesh the South Island of New Zealand
 clearvars; clc;
-addpath(genpath('utilities/'))
-addpath(genpath('datasets/'))
-addpath(genpath('m_map/'))
+
+addpath(genpath('../utilities/'))
+addpath(genpath('../datasets/'))
+addpath(genpath('../m_map/'))
+
 %% STEP 1: set mesh extents and set parameters for mesh.
 bbox = [166 176;		% lon_min lon_max
         -48 -40]; 		% lat_min lat_max

--- a/Examples/Example_2_NY.m
+++ b/Examples/Example_2_NY.m
@@ -1,8 +1,10 @@
 % Example_2_NY: Mesh the New York region in high resolution
 clearvars; clc;
-addpath(genpath('utilities/'))
-addpath(genpath('datasets/'))
-addpath(genpath('m_map/'))
+
+addpath(genpath('../utilities/'))
+addpath(genpath('../datasets/'))
+addpath(genpath('../m_map/'))
+
 %% STEP 1: Set mesh extents and set parameters for mesh.
 min_el    = 30;  	% Minimum resolution in meters.
 max_el    = 1e3; 	% Maximum resolution in meters. 

--- a/Examples/Example_3_ECGC.m
+++ b/Examples/Example_3_ECGC.m
@@ -1,9 +1,11 @@
 % Example_3_ECGC: Mesh the greater US East Coast and Gulf of Mexico region
 % with a high resolution inset around New York
+
 clearvars; clc;
-addpath(genpath('utilities/'));
-addpath(genpath('datasets/'));
-addpath(genpath('m_map/'));
+
+addpath(genpath('../utilities/'));
+addpath(genpath('../datasets/'));
+addpath(genpath('../m_map/'));
 
 % WJP: 08/02/2019: Updated to demonstrate using non-box 
 % (arbitrary polygon's) bbox's in both outer and inner meshes

--- a/Examples/Example_4_PRVI.m
+++ b/Examples/Example_4_PRVI.m
@@ -4,9 +4,9 @@
 % around 1 hr. 
 clc; clearvars
 
-addpath(genpath('utilities/'))
-addpath(genpath('datasets/'))
-addpath(genpath('m_map/'))
+addpath(genpath('../utilities/'))
+addpath(genpath('../datasets/'))
+addpath(genpath('../m_map/'))
 
 %% The constant parameters for all domains
 wl        = 30;         % elements to resolve M2 wavelength

--- a/Examples/Example_5_JBAY.m
+++ b/Examples/Example_5_JBAY.m
@@ -1,10 +1,11 @@
 % Example_5_JBAY: Mesh the New York Jamaica bay (JBAY) region in 
 % high resolution.
+
 clc; clearvars
 
-addpath(genpath('utilities/'));
-addpath(genpath('datasets/'));
-addpath(genpath('m_map/')); 
+addpath(genpath('../utilities/'));
+addpath(genpath('../datasets/'));
+addpath(genpath('../m_map/')); 
 
 %% STEP 1: set mesh extents and set parameters for mesh.
 bbox      = [-73.97 -73.75 	% lon_min lon_max

--- a/Examples/Example_5b_JBAY_w_weirs.m
+++ b/Examples/Example_5b_JBAY_w_weirs.m
@@ -3,9 +3,9 @@
 % high resolution with two 15-30 m wide weirs at the mouth of the estuary.
 clc; clearvars
 
-addpath(genpath('utilities/'));
-addpath(genpath('datasets/'));
-addpath(genpath('m_map/'));
+addpath(genpath('../utilities/'));
+addpath(genpath('../datasets/'));
+addpath(genpath('../m_map/'));
 
 %% STEP 1: set mesh extents and set parameters for mesh.
 bbox      = [-73.97 -73.75 	% lon_min lon_max

--- a/Examples/Example_6_GBAY.m
+++ b/Examples/Example_6_GBAY.m
@@ -1,10 +1,11 @@
 % Example_6_GBAY: Mesh the Galveston bay (GBAY) region in
 % high resolution.
+
 clearvars; clc;
 
-addpath(genpath('utilities/'))
-addpath(genpath('datasets/'))
-addpath(genpath('m_map/'))
+addpath(genpath('../utilities/'))
+addpath(genpath('../datasets/'))
+addpath(genpath('../m_map/'))
 
 %% STEP 1: set mesh extents and set parameters for mesh.
 bbox = [-95.40 -94.4;

--- a/Examples/Example_6b_GBAY_w_floodplain.m
+++ b/Examples/Example_6b_GBAY_w_floodplain.m
@@ -1,12 +1,13 @@
 % Example_6b_GBAY_w_floodplain
 % Continue on from Example_6_GBAY.m by building on
 % a floodplain onto the mesh.
-%%
-clearvars; close all; clc;
 
-addpath(genpath('utilities/'))
-addpath(genpath('datasets/'))
-addpath(genpath('m_map/'))
+clearvars; clc;
+
+addpath(genpath('../utilities/'))
+addpath(genpath('../datasets/'))
+addpath(genpath('../m_map/'))
+
 %% STEP 1: set mesh extents and set parameters for mesh.
 min_el    = 60;  		    % Minimum mesh resolution in meters.
 max_el    = [1e3 0 -inf     % Globally, maximum mesh resolution in meters.

--- a/Examples/Example_7_Global.m
+++ b/Examples/Example_7_Global.m
@@ -1,8 +1,10 @@
 % Example_7_Global: Make a global mesh
+
 clearvars; clc;
-addpath(genpath('utilities/'));
-addpath(genpath('datasets/'));
-addpath(genpath('m_map/'));
+
+addpath(genpath('../utilities/'));
+addpath(genpath('../datasets/'));
+addpath(genpath('../m_map/'));
 
 %% STEP 1: set mesh extents and set parameters for mesh. 
 %% The greater US East Coast and Gulf of Mexico region

--- a/Examples/Example_8_AK.m
+++ b/Examples/Example_8_AK.m
@@ -8,9 +8,10 @@
 % -180 to 180 deg format. 
 
 clearvars; clc;
-addpath(genpath('utilities/'))
-addpath(genpath('datasets/'))
-addpath(genpath('m_map/'))
+
+addpath(genpath('../utilities/'))
+addpath(genpath('../datasets/'))
+addpath(genpath('../m_map/'))
 
 %% STEP 1: set mesh extents and set parameters for mesh.
 % This is a polygonal shape for west Alaska/Bering Shelf 

--- a/utilities/m_trisurf.m
+++ b/utilities/m_trisurf.m
@@ -1,5 +1,5 @@
-function [h]=m_trisurf(tri,long,lat,z)
-%  h = m_trisurf(tri,long,lat,z)
+function [h]=m_trisurf(tri,long,lat,z,facecolor)
+%  h = m_trisurf(tri,long,lat,z,varargin)
 %  
 global MAP_PROJECTION
 
@@ -10,6 +10,11 @@ if isempty(MAP_PROJECTION)
     return;
 end
 
+% facecolor
+if nargin < 5
+    facecolor = 'interp';
+end
+
 % Plotting with a trick to fill in the whole plotting space.
 [Xp,Yp] = m_ll2xy(long,lat,'clip','patch');
 [X,Y] = m_ll2xy(long,lat,'clip','point');
@@ -17,5 +22,5 @@ tx = X(tri); ty = Y(tri);
 I = (isnan(tx(:,1)) | isnan(ty(:,1))) & ...
     (isnan(tx(:,2)) | isnan(ty(:,2))) & ...
     (isnan(tx(:,3)) | isnan(ty(:,3)));
-hold on; h = trisurf(tri(~I,:),Xp,Yp,z,'facecolor', 'interp', 'edgecolor', 'none');
+hold on; h = trisurf(tri(~I,:),Xp,Yp,z,'facecolor', facecolor, 'edgecolor', 'none');
 end


### PR DESCRIPTION
- Use the genpath with "../" because examples are now in a directory ahead.
- Keep same spacing for all examples at top
- At the facecolor optional input for m_trisurf