### PR TITLE
Changes to geodata

### DIFF
--- a/utilities/m_tricontour.m
+++ b/utilities/m_tricontour.m
@@ -1,7 +1,7 @@
 function H = m_tricontour(tri,p,z,N,C)
-%  M_CONTOURF Adds filled contours to a map
-%    M_CONTOUR(LONG,LAT,DATA,...)
-%
+%   H = m_tricontour(tri,p,z,N,C)
+%   N-> number of contour levels
+%   C-> linespec color
 global MAP_PROJECTION
 
 % Have to have initialized a map first


### PR DESCRIPTION
- No bbox with pslg option error catching
- Only read in dem with stride if memory bound. Otherwise just faster to read in dem with no stride and then coarsen.
- In the plotting, make new line colors and don't redo the m_grid() call if using the holdon feature. (So you can add shorelines to the plot of the mesh triangulation for example).