### PR TITLE
correcting the extractContour

### DIFF
--- a/@edgefx/edgefx.m
+++ b/@edgefx/edgefx.m
@@ -723,14 +723,25 @@ classdef edgefx
                 val = obj.F.Values;
                 tt = 'Total EdgeLength Function';
             end
+          
+            % working out stride
+            mem = inf; stride = obj.gridspace;
+            while mem > 1
+                xx = obj.x0y0(1):stride:obj.bbox(1,2);
+                yy = obj.x0y0(2):stride:obj.bbox(2,2);
+                xs = whos('xx'); ys = whos('yy');
+                mem = xs.bytes*ys.bytes/1e9;
+                stride = stride*2;
+            end
+            stride = ceil(stride/obj.gridspace);
+            I = [1:stride:size(xgrid,1)];
+            J = [1:stride:size(xgrid,2)];
             
             figure;
             m_proj('merc',...
                 'long',[obj.bbox(1,1) obj.bbox(1,2)],...
                 'lat',[obj.bbox(2,1) obj.bbox(2,2)])
-            hold on; m_fastscatter(xgrid,...
-                ygrid,...
-                val);
+            hold on; m_fastscatter(xgrid(I,J),ygrid(I,J),val(I,J));
             cb = colorbar; ylabel(cb,'edgelength in meters');
             colormap(lansey)
             m_grid() %'xtick',10,'tickdir','out',...

--- a/@geodata/geodata.m
+++ b/@geodata/geodata.m
@@ -730,13 +730,20 @@ classdef geodata
         
         function obj = extractContour(obj,ilev)
             % Extract a geometric contour from the DEM at elevation ilev.
+            % obj = extractContour(obj,ilev)
+            %
+            % Can use to get the mean sea level contour, e.g.;
+            % gdat = geodata('pslg',0,'h0',min_el,'dem',dem); % make the dummy gdat for the dem extents;
+            % lmsl = extractContour(gdat,0); %using the dummy gdat with dem info to get the 'lmsl' gdat with the 0-m contour.
+            
             [node,edge] = ...
                 getiso2( obj.Fb.GridVectors{1},obj.Fb.GridVectors{2},...
-                double(obj.Fb.Values),ilev) ;
+                double(obj.Fb.Values'),ilev) ;
             
             polyline = cell2mat(extdom_polygon(edge,node,-1,1,10)') ;
             
-            obj = geodata('pslg',polyline,'h0',obj.h0,'dem',obj.demfile) ;
+            obj = geodata('pslg',polyline,'bbox',obj.bbox,...
+                          'h0',obj.h0,'dem',obj.demfile) ;
             
         end
         

--- a/@geodata/geodata.m
+++ b/@geodata/geodata.m
@@ -803,9 +803,18 @@ classdef geodata
             % select optional types
             switch type
                 case('dem')
-                    % interpolate DEM's bathy linearly onto our edgefunction grid.
-                    [demx,demy] = ndgrid(obj.x0y0(1):obj.h0/111e3:obj.bbox(1,2), ...
-                        obj.x0y0(2):obj.h0/111e3:obj.bbox(2,2));
+                    % interpolate DEM's bathy linearly onto our 
+                    % edgefunction grid (or a coarsened version of it for
+                    % memory considerations)
+                    mem = inf; stride = obj.h0/111e3;
+                    while mem > 1
+                        xx = obj.x0y0(1):stride:obj.bbox(1,2);
+                        yy = obj.x0y0(2):stride:obj.bbox(2,2);
+                        xs = whos('xx'); ys = whos('yy');
+                        mem = xs.bytes*ys.bytes/1e9;
+                        stride = stride*2;
+                    end
+                    [demx,demy] = ndgrid(xx,yy);
                     demz = obj.Fb(demx,demy);
                     if ~isempty(obj.inner) && obj.inner(1) ~= 0
                         poly = [obj.outer; obj.inner];

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -1654,8 +1654,13 @@ classdef msh
                         vend   = bndidx(vend);
                     else
                         vstart = varargin{2}; vend = varargin{3};
-                        if length(varargin) >= 5
-                            type = varargin{4}; type2 = varargin{5};
+                        if length(varargin) >= 4
+                            type = varargin{4}; 
+                            if length(varargin) >= 5
+                                type2 = varargin{5};
+                            else
+                                type2 = type;
+                            end
                             [~,~,obj.op,obj.bd] = extract_boundary(vstart,vend,bnde,obj.p,...
                                 dir,obj.op,obj.bd,type,type2); %<--updates op and bd.
                             return;


### PR DESCRIPTION
- correcting extractContour to actually work (required flipping the Fb.Values and entering the bbox info to geodata call)
- adding help and a usage example
- adding strides for geodata and edgefx plotting to avoid memory issues when plotting large datasets
- correcting make_bc 'outer' option to match varargins for elevation "type" bc which does not require any "type2" variable to be specified. Type is 'elevation' or 'flux' type bc. Type2 is when type is 'flux', is it 'river' or ''zero flux' bc?