### PR TITLE
improvements to extracting subdomain

### DIFF
--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -327,32 +327,21 @@ classdef msh
                     end
                     if ~isempty(obj.bd)
                         for nb = 1 : obj.bd.nbou
-                            if obj.bd.ibtype(nb) == 94
-                                if proj
-                                    m_plot(obj.p(obj.bd.nbvv(:),1),...
-                                        obj.p(obj.bd.nbvv(:),2),...
-                                        'r.','linewi',1.2);
-                                else
-                                    plot(obj.p(obj.bd.nbvv(:),1),...
-                                        obj.p(obj.bd.nbvv(:),2),...
-                                        'r.','linewi',1.2);
-                                end
-                                % internal weirs
-                            elseif obj.bd.ibtype(nb)  == 24
+                            if obj.bd.ibtype(nb)  == 24 || obj.bd.ibtype(nb) == 94
                                 if proj
                                     % plot front facing
                                     m_plot(obj.p(obj.bd.nbvv(1:obj.bd.nvell(nb),nb),1),...
                                         obj.p(obj.bd.nbvv(1:obj.bd.nvell(nb),nb),2),'g-','linewi',1.2);
                                     % plot back facing
                                     m_plot(obj.p(obj.bd.ibconn(1:obj.bd.nvell(nb),nb),1),...
-                                        obj.p(obj.bd.ibconn(1:obj.bd.nvell(nb),nb),2),'g-','linewi',1.2);
+                                        obj.p(obj.bd.ibconn(1:obj.bd.nvell(nb),nb),2),'y-','linewi',1.2);
                                 else
                                     % plot front facing
                                     plot(obj.p(obj.bd.nbvv(1:obj.bd.nvell(nb),nb),1),...
                                         obj.p(obj.bd.nbvv(1:obj.bd.nvell(nb),nb),2),'g-','linewi',1.2);
                                     % plot back facing
                                     plot(obj.p(obj.bd.ibconn(1:obj.bd.nvell(nb),nb),1),...
-                                        obj.p(obj.bd.ibconn(1:obj.bd.nvell(nb),nb),2),'g','linewi',1.2);
+                                        obj.p(obj.bd.ibconn(1:obj.bd.nvell(nb),nb),2),'y-','linewi',1.2);
                                 end
                             elseif obj.bd.ibtype(nb)  == 20
                                 if proj
@@ -846,6 +835,12 @@ classdef msh
                     idx=perm_inv(idx);
                     obj.f13.userval.Atr(i).Val(1,:) = idx;
                 end
+            end
+            
+            if ~isempty(obj.f5354)
+                disp('Renumbering the fort.5354...');
+                idx = perm_inv(obj.f5354.nodes);
+                obj.f5354.nodes = idx;
             end
         end
 

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -2092,10 +2092,13 @@ classdef msh
                     % extract the inner region of obj1 (inset) from obj2 (base)
                     % assuming that the inset fits perfectly in the base
                     if extract
-                        K = boundary(obj1.p(:,1),obj1.p(:,2));
-                        bou = obj1.p(K,:);
-                        obj2o = obj2;
-                        obj2 = ExtractSubDomain(obj2,bou,1);
+                        [p1(:,1),p1(:,2)] = m_ll2xy(p1(:,1),p1(:,2)) ;
+                        [p2(:,1),p2(:,2)] = m_ll2xy(p2(:,1),p2(:,2)) ;
+                        cell2 = extdom_polygon(extdom_edges2(t1,p1),p1,-1,0);
+                        bou = cell2{1}(1:end-1,:);
+                        obj2o = obj2; obj2.p = p2;
+                        obj2 = ExtractSubDomain(obj2,bou,1,1);
+                        [obj2.p(:,1),obj2.p(:,2)] = m_xy2ll(obj2.p(:,1),obj2.p(:,2));
                     end
                     % concatenate
                     m1 = cat(obj1,obj2);
@@ -2429,7 +2432,7 @@ classdef msh
             obj.bd.nvel = 2*sum(obj.bd.nvell);
             % nbvv is a matrix of boundary nodes
             [nr1,nc1]=size(obj.bd.nbvv);
-            [nr2,nc2]=size(obj1.bd.nbvv);
+            nc2 = sum(jj); nr2 = sum(obj1.bd.nvell(jj));
             nbvv_old = obj.bd.nbvv;
             ibconn_old = obj.bd.ibconn;
             barinht_old = obj.bd.barinht;

--- a/@msh/private/readfort15.m
+++ b/@msh/private/readfort15.m
@@ -161,7 +161,7 @@ for k = 1: f15dat.ntif
     ll = fgetl(fid);
     ll(strfind(ll,'!'):end) = [];
     f15dat.tipotag(k).name = strtrim(ll);
-    f15dat.tipotag(k).val =  readlinevec( fid ) ; 
+    f15dat.tipotag(k).val =  readlinevec( fid )' ; 
 end
  
 % NBFR
@@ -170,7 +170,7 @@ for k = 1: f15dat.nbfr
     ll = fgetl(fid);
     ll(strfind(ll,'!'):end) = [];
     f15dat.bountag(k).name = strtrim(ll);
-    f15dat.bountag(k).val = readlinevec( fid ) ; 
+    f15dat.bountag(k).val = readlinevec( fid )' ; 
 end
 
 % Open boundary harmonic forcing  
@@ -183,7 +183,7 @@ for k = 1: f15dat.nbfr
     
     val = fscanf(fid, '%f %f \n', [2 nvd] ) ; 
     
-    f15dat.opeemoefa(k).val = val' ; 
+    f15dat.opealpha(k).val = val' ; 
 end
 
 

--- a/@msh/private/writefort14.m
+++ b/@msh/private/writefort14.m
@@ -110,8 +110,12 @@ if ~isempty(boudat)
                 %otherwise
                 %    msgline = fgetl(fid) ;
             case 94
-                fprintf( fid, '%d %d \n' , boudat.nbvv(:,1:2)' ) ;
-                
+                idx = find( boudat.nbvv(:,i) ) ;
+                nbvv = full(boudat.nbvv(idx,i)) ;
+                ibconn = full(boudat.ibconn(idx,i)) ;
+                for ll = 1: length(idx)
+                    fprintf( fid, '%d %d \n' , nbvv(ll), ibconn(ll) ) ;
+                end
         end
     end
     % case of no bou

--- a/utilities/Calc_f13.m
+++ b/utilities/Calc_f13.m
@@ -12,6 +12,7 @@ function obj = Calc_f13(obj,attribute,varargin)
 %              'Ss' ('surface_submergence_state')
 %              'Re' ('initial_river_elevation')
 %              'Ad' ('advection_state')
+%              'Sb' ('subgrid_barrier')
 %
 %            3) then either: 
 %              'inpoly' followed by...
@@ -51,6 +52,9 @@ elseif strcmpi(attribute,'Re')
 elseif strcmpi(attribute,'Ad')
     attrname = 'advection_state';
     default_val = -999;
+elseif strcmpi(attribute,'Sb')
+     attrname = 'subgrid_barrier';
+     default_val = 99999;
 else
     error(['Attribute ' attribute ' not currently supported'])
 end

--- a/utilities/Calc_tau0.m
+++ b/utilities/Calc_tau0.m
@@ -5,11 +5,25 @@ function obj = Calc_tau0(obj,varargin)
 %
 %  Inputs:   1) A msh class obj with bathy on it
 %            2) Optional name-value arguments:
-%               'distance': the cutoff mean distance to neighbouring nodes
+%             - 'opt': -3 [default] => calculates spatially varying tau0
+%                                      factors
+%                     +ve => calculates the stable positive tau0 based on 
+%                            the value of 'opt', which is the intended 
+%                            simulation timestep
+%
+%             additional varargin options for 'opt' = -3:
+%             - 'distance': the cutoff mean distance to neighbouring nodes
 %               to switch between depth based tau0 (below) and the default
 %               value, 0.03 (default distance is 2 [km])
-%               'depth': the cutoff depth to switch between 0.005
+%             - 'depth': the cutoff depth to switch between 0.005
 %               and 0.02 (default is 10 [m])
+%
+%             additional varargin options for 'opt' = +ve:
+%             - 'kappa': the value of the time weighting factor, kappa for 
+%                        the future time step. Must be <= 1 and is 0.5 
+%                        by default.
+%             - 'sf': the safety factor applied to the stable value of
+%                     tau0. Must be <= 1 and is 0.6 by default. 
 %
 %  Outputs: 1) msh class obj with primitive_weighting_in_continuity_equation
 %              values populating the f13 struct

--- a/utilities/ExtractSubDomain.m
+++ b/utilities/ExtractSubDomain.m
@@ -1,13 +1,25 @@
-function [obj,ind] = ExtractSubDomain(obj,bou,keep_inverse)
-% [obj,ind] = ExtractSubDomain(obj,bou,keep_inverse)
+function [obj,ind] = ExtractSubDomain(obj,bou,keep_inverse,centroid)
+% [obj,ind] = ExtractSubDomain(obj,bou,keep_inverse,centroid)
+%
+% bou: a polygon or a bbox to extract sub-domain (no NaNs allowed)
+% keep_inverse: = 0 [default] to get the sub-domain inside the bou polygon
+%               = 1 to get the sub-domain outside the bou polygon
+% centroid: = 0 [default] inpolygon test is based on whether all vertices
+%              of the element are inside (outside) the bou polygon
+%           = 1 inpolygon test is based on whether the element centroid
+%              is inside (outside) the bou polygon
+% 
 p = obj.p; t = obj.t; 
 if nargin == 1 || (nargin == 3 && isempty(bou))
     plot(p(:,1),p(:,2),'k.');
     h = impoly;
     bou  = h.getPosition;
 end
-if nargin == 2
+if nargin < 3
     keep_inverse = 0;
+end
+if nargin < 4
+    centroid = 0;
 end
 if size(bou,1) == 2
      bou = [bou(1,1) bou(2,1);
@@ -16,10 +28,14 @@ if size(bou,1) == 2
             bou(1,2) bou(2,1); ...
             bou(1,1) bou(2,1)];
 end
-bxy1 = p(t(:,1),:); bxy2 = p(t(:,2),:); bxy3 = p(t(:,3),:); 
-in1 = inpoly(bxy1,bou); in2 = inpoly(bxy2,bou); in3 = inpoly(bxy3,bou);
-in = in1 & in2 & in3;
-
+if centroid
+    bxyc = baryc(obj);
+    in = inpoly(bxyc,bou);
+else
+    bxy1 = p(t(:,1),:); bxy2 = p(t(:,2),:); bxy3 = p(t(:,3),:); 
+    in1 = inpoly(bxy1,bou); in2 = inpoly(bxy2,bou); in3 = inpoly(bxy3,bou);
+    in = in1 & in2 & in3;
+end
 if keep_inverse == 0
     t(~in,:) = [];
 else


### PR DESCRIPTION
- In the plus 'matche' case improve extraction to work for global obj2 meshes
- In the ExtractSubdomain, add the option to extract domain based on element centroids instead of default behavior which requires all vertices of an element to be inside polygon
- Correcting the carryoverweirs for carrying over the existing size of the nbvv array
- Adding Zach's new Subgrid barrier f13 attribute to Calc_f13
- updating the Calc_tau0 function help for the positive tau0 option
- updating ibtype  = 94 'bd' construction
- making readfort15.m consistent with writefort15.m for the reading of the tidal properties. 
- adding f5354 renumbering