### PR TITLE
Adding legacy extension for ADCIRC meshes

### DIFF
--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -124,7 +124,7 @@ classdef msh
                 error('See usage instructions above. Please specify the fname of the mesh as a name/value pair...');
             end
 
-            if any(contains(fname,'.14'))
+            if any(contains(fname,'.14')) || any(contains(fname,'.grd'))
                 disp('INFO: An ADCIRC fort.14 file will be read...')
                 bdflag = 1;
                 if nob


### PR DESCRIPTION
While the `.grd` extension isn't a correct representation of what the meshes represent (i.e. unstructured mesh versus structured "grid"), there are ~20 years of meshes that use the incorrect extension. This adds the ability to read in meshes from the before times without the need to rename files in an archive.