### PR TITLE
fixing auto dt sizing function

### DIFF
--- a/@edgefx/edgefx.m
+++ b/@edgefx/edgefx.m
@@ -966,18 +966,19 @@ classdef edgefx
                     error('MinCr is > MaxCr, please switch order in dt name value call')
                 end
                 
+                % Automatic timestep selection option (for ADCIRC models)
+                if desDt == 0
+                    hh_d(hh_d < obj.h0) = obj.h0;
+                    obj.dt = min(min(maxCr*hh_d./u));
+                    desDt  = obj.dt;
+                end
+                
                 % Enforcement of Courant bounds in mesh size function
                 fprintf(1, [ ...
                     'Enforcing timestep of ',num2str(desDt),' seconds ', ...
                     'with Courant number bounds of ',num2str(minCr),' to ',num2str(maxCr),'\n', ...
                     ] ) ;
                 
-                % Automatic timestep selection option (for ADCIRC models)
-                if desDt == 0
-                    hh_d(hh_d < obj.h0) = obj.h0;
-                    obj.dt = min(min(minCr*hh_d./u));
-                    desDt  = obj.dt;
-                end
                 
                 Cr = (desDt*u)./hh_m; % Courant number for given desDt for mesh size variations
                 

--- a/@edgefx/edgefx.m
+++ b/@edgefx/edgefx.m
@@ -6,7 +6,7 @@ classdef edgefx
     %   Copyright (C) 2018  Keith Roberts & William Pringle
     %
     %   The following properties (with default values) are available for input
-    %   to the edgefx method: 
+    %   to the edgefx method:
     %      defval = 0; % placeholder value if arg is not passed.
     %      addOptional(p,'dis',defval);
     %      addOptional(p,'fs',defval);
@@ -41,13 +41,13 @@ classdef edgefx
         nx % number of x coords
         ny % number of y coords
         x0y0 % 2-tuple of bot. left of domain
-        
+
         lmsl % lmsl boundary as a geodata class
-        
+
         bbox
         boubox
         used % edge function keywords
-        
+
         dis  % percent the edgelength changes in space
         fd   % distance function
         hhd  % matrix containing distance fx values.
@@ -63,22 +63,22 @@ classdef edgefx
         AngOfRe % Angle of reslope
         g    % max allowable grade of mesh.
         dt   % theoretical simulateable timestep
-        
+
         F    % edge function in gridded interpolant format.
-        
+
         h0    % min. resolution of edgelength function in meters
         gridspace % edgelength function resolution in WGS84 degrees.
         max_el % max. resolution in domain
         max_el_ns % max. resolution +-<0.01 from shoreline
         boudist % distance in WGS84 degrees to boundary of mesh
-        
+
         min_el_ch % min. element size along the channel
         Channels % cell array of streams.
-        
+
     end
-    
+
     methods
-        
+
         %% Class constructor/pass it a shape class and edgefx params.
         function obj = edgefx(varargin)
             % Check for m_map dir
@@ -86,7 +86,7 @@ classdef edgefx
             if exist('m_proj','file')==2
               M_MAP_EXISTS=1 ;
             end
-            if M_MAP_EXISTS~=1 
+            if M_MAP_EXISTS~=1
               error('Where''s m_map? Chief, you need to read the user guide')
             end
 
@@ -95,12 +95,12 @@ classdef edgefx
             if exist('inpoly.m','file')
               UTIL_DIR_EXISTS=1 ;
             end
-            if UTIL_DIR_EXISTS~=1 
+            if UTIL_DIR_EXISTS~=1
               error('Where''s the utilities directory? Chief, you need to read the user guide')
             end
 
             p = inputParser;
-            
+
             defval = 0; % placeholder value if arg is not passed.
             % add name/value pairs
             addOptional(p,'dis',defval);
@@ -119,7 +119,7 @@ classdef edgefx
             addOptional(p,'fl',defval);
             addOptional(p,'Channels',defval);
             addOptional(p,'h0',defval);
-            
+
             % parse the inputs
             parse(p,varargin{:});
             % store the inputs as a struct
@@ -132,7 +132,7 @@ classdef edgefx
             fields = fieldnames(inp);
             % loop through and determine which args were passed.
             % also, assign reasonable default values if some options were
-            
+
             % not assigned.
             for i = 1 : numel(fields)
                 type = fields{i};
@@ -196,7 +196,7 @@ classdef edgefx
                         end
                 end
             end
-            
+
             % kjr april 28, 2018-form mesh size grid on-the-fly
             obj.fd       = @dpoly;
             obj.x0y0     = feat.x0y0 + sqrt(eps);
@@ -205,7 +205,7 @@ classdef edgefx
             obj.ny       = ceil(abs(feat.x0y0(2)-feat.bbox(2,2))/obj.gridspace);
             obj.bbox     = feat.bbox;
             obj.boubox   = feat.boubox;
-            
+
             % WJP: Do Mercator projection for calculating
             % distances from shoreline
             if feat.bbox(1,2) > 180
@@ -268,7 +268,7 @@ classdef edgefx
                 end
             end
         end
-        
+
         %% Traditional distance function, linear distance from coastline.
         function obj = distfx(obj,feat)
             [d,obj] = get_dis(obj,feat);
@@ -289,7 +289,7 @@ classdef edgefx
             % distance function!
             [d,obj] = get_dis(obj,feat);
             obj.boudist = d ;
-            
+
             [xg,yg] = CreateStructGrid(obj);
             % use a harvestine assumption
             dx = obj.h0*cosd(yg(1,:)); % for gradient function
@@ -341,7 +341,7 @@ classdef edgefx
                 x_kp( prune ) = [];
                 y_kp( prune ) = [];
             end
-            
+
             % Now get the feature size along the coastline
             if length(x_kp) > 12
                 % Use KD-tree
@@ -385,22 +385,22 @@ classdef edgefx
             end
             clear x_kp y_kp d d_fs dPOS xg yg
         end
-        
+
         function [d,obj] = get_dis(obj,feat)
             % Function used by distfx and featfx to return distance
             % and make the Fdis interpolant
             d = feval(obj.fd,obj,feat);
             d = reshape(d,obj.nx,[]);
         end
-        
+
         %% Wavelength edgefx.
         function obj = wlfx(obj,feat)
-            
+
             % interpolate DEM's bathy linearly onto our edgefunction grid.
             [xg,yg] = CreateStructGrid(obj);
             tmpz    = feat.Fb(xg,yg);
             if ~isempty(feat.Fb2)
-               tmpz2 = feat.Fb2(xg,yg); 
+               tmpz2 = feat.Fb2(xg,yg);
                tmpz(isnan(tmpz)) = tmpz2(isnan(tmpz));
                clear tmpz2
             end
@@ -408,7 +408,7 @@ classdef edgefx
             obj.wld = NaN([obj.nx,obj.ny]);
             grav    = 9.807;
             period  = 12.42*3600; % M2 period in seconds
-            
+
             for param = obj.wl'
                 if numel(param)==1
                     % no bounds specified.
@@ -430,16 +430,16 @@ classdef edgefx
             end
             clearvars tmpz xg yg;
         end
-        
+
         %% Topographic length scale/slope edge function.
       %% Topographic length scale/slope edge function.
         function obj = slpfx(obj,feat)
-            
+
             [xg,yg] = CreateStructGrid(obj);
-            
+
             tmpz    = feat.Fb(xg,yg);
             if ~isempty(feat.Fb2)
-               tmpz2 = feat.Fb2(xg,yg); 
+               tmpz2 = feat.Fb2(xg,yg);
                tmpz(isnan(tmpz)) = tmpz2(isnan(tmpz));
                clear tmpz2
             end
@@ -490,13 +490,13 @@ classdef edgefx
                     tmpz_f = tmpz_f + tmpz_ft;
                 end
             end
-            
+
             % Rossby radius of deformation filter
             if filtit == 1
                 tic
                 bs = NaN([obj.nx,obj.ny]);
                 % break into 10 deg latitude chunks, or less if higher res
-                div = ceil(min(1e7/obj.nx,10*obj.ny/(max(yg(:))-min(yg(:))))); 
+                div = ceil(min(1e7/obj.nx,10*obj.ny/(max(yg(:))-min(yg(:)))));
                 grav = 9.807;
                 nb = ceil(obj.ny/div);
                 n2s = 1;
@@ -606,7 +606,7 @@ classdef edgefx
                 bs      = sqrt(bx.^2 + by.^2); % get overall slope
             end
             clear bx by tmpz_f tmpz_ft
-            
+
             % Allow user to specify depth ranges for slope parameter.
             obj.slpd = NaN([obj.nx,obj.ny]);
             for param = obj.slp'
@@ -630,12 +630,12 @@ classdef edgefx
             end
             clearvars tmpz xg yg
         end
-        
+
         %% Channel edgefunction
         function obj = chfx(obj,feat)
-            
+
             ang_of_reslope=obj.AngOfRe ;      % Estimate width of channel using tangent of this angle times depth.
-            
+
             % STEP 1: Calculate the width of each channel using a v-shape approx to
             % channel's cross sectional area.
             for jj = 1:length(obj.Channels)
@@ -645,9 +645,9 @@ classdef edgefx
                 radii{jj}=(tand(ang_of_reslope)*max(1,-dp{jj}));         % estimate of channel's width in degrees at x,y locations ASSUMING angle of reslope
                 tempbb{jj} = feat.boubox;
             end
-            
+
             [xg,yg] = CreateStructGrid(obj);
-            
+
             % STEP 2: For each channel point, set the resolution around a
             % neighborhood of points as |h|/ch where ch is non-dim # between 0.5-1.5
             obj.chd = NaN([obj.nx,obj.ny]);
@@ -655,7 +655,7 @@ classdef edgefx
             % partially enclosed in boubox
             isin = cellfun(@inpolysum,pts,tempbb);
             pts(isin==0) = []; radii(isin==0)= [];
-            
+
             %figure; plot(xg,yg,'k.');
             tic
             tidx = [];
@@ -679,10 +679,10 @@ classdef edgefx
                     tidx = [tidx; temp];
                 end
             end
-            toc 
+            toc
             tmpz = feat.Fb(xg(tidx),yg(tidx));
             if ~isempty(feat.Fb2)
-               tmpz2 = feat.Fb2(xg(tidx),yg(tidx)); 
+               tmpz2 = feat.Fb2(xg(tidx),yg(tidx));
                tmpz(isnan(tmpz)) = tmpz2(isnan(tmpz));
                clear tmpz2
             end
@@ -691,14 +691,14 @@ classdef edgefx
             obj.chd(obj.chd < obj.min_el_ch) = obj.min_el_ch;
             clearvars Fb pts dp radii tempbb xg yg
         end
-        
-        
+
+
         %% General function to plot
         function plot(obj,type)
             % form grid here.
             % working out plottable size
             [xgrid,ygrid] = CreateStructGrid(obj);
-            
+
             if nargin == 2
                 switch type
                     case('dis')
@@ -723,7 +723,7 @@ classdef edgefx
                 val = obj.F.Values;
                 tt = 'Total EdgeLength Function';
             end
-          
+
             % working out stride
             mem = inf; stride = obj.gridspace;
             while mem > 1
@@ -736,7 +736,7 @@ classdef edgefx
             stride = ceil(stride/obj.gridspace);
             I = [1:stride:size(xgrid,1)];
             J = [1:stride:size(xgrid,2)];
-            
+
             figure;
             m_proj('merc',...
                 'long',[obj.bbox(1,1) obj.bbox(1,2)],...
@@ -748,7 +748,7 @@ classdef edgefx
             % 'yaxislocation','left','fontsize',7);
             title(tt);
         end
-        
+
         %% Finalize edge function
         % Add grading, cfl limiting and bound enforcement.
         function obj = finalize(obj,feat)
@@ -782,18 +782,18 @@ classdef edgefx
                         error('FATAL:  Could not finalize edge function');
                 end
             end
-            
+
             [hh_m] = min(hh,[],3);
             clearvars hh
-            
+
             [xg,yg] = CreateStructGrid(obj);
-            
+
             % Before grading, ensure edgefx reflects the spacing in
             % proximity to constraints.
             if ~isempty(feat.weirs)
                 % form temporary mesh size function interpolat
                 % if spacing is negative -999 then it will use the mesh
-                % size function to determine the spacing. 
+                % size function to determine the spacing.
                 %Ftmp = griddedInterpolant(xg,yg,hh_m,'linear','nearest');
 
                 for i =1:length(feat.weirs)
@@ -823,43 +823,43 @@ classdef edgefx
                     end
                 end
             end
-            
-            
+
+
             % enforce all mesh resolution bounds,grade and enforce the CFL in planar metres
             if ~isinf(obj.max_el_ns) && ~isempty(obj.boudist)
-                nearshore = abs(obj.boudist) < 2/3*obj.h0; 
+                nearshore = abs(obj.boudist) < 2/3*obj.h0;
                 hh_m(nearshore & hh_m > obj.max_el_ns) = obj.max_el_ns;
             end
             hh_m(hh_m < obj.h0 ) = obj.h0;
-            
+
             % Compute tmpz if necessary
             if length(obj.max_el) > 1 || length(obj.g) > 1 || obj.dt(1) >= 0
                 tmpz    = feat.Fb(xg,yg);
                 if ~isempty(feat.Fb2)
-                   tmpz2 = feat.Fb2(xg,yg); 
+                   tmpz2 = feat.Fb2(xg,yg);
                    tmpz(isnan(tmpz)) = tmpz2(isnan(tmpz));
                    clear tmpz2
                 end
             end
-            
+
             for param = obj.max_el'
                 if numel(param)==1 && param~=0
                     mx   = obj.max_el(1);
                     limidx = hh_m > mx | isnan(hh_m);
-                    
+
                     hh_m( limidx ) = mx;
                 else
                     mx  = param(1);
                     dp1 = param(2);
                     dp2 = param(3);
-                    
+
                     limidx = (tmpz < dp1 & tmpz > dp2) & ...
                              (hh_m > mx | isnan(hh_m));
-                    
+
                     hh_m( limidx ) = mx;
                 end
             end
-            
+
             % Make sure this is called before releasing memory...
             if obj.dt(1) == 0
                 % Find min allowable dt based on dis or fs function
@@ -872,19 +872,19 @@ classdef edgefx
                            'limiter without specifying dis or fs option']);
                 end
             end
-            
+
             obj = release_memory(obj) ;
 
             disp('Relaxing the mesh size gradient');
-            if all(abs(obj.bbox(1,:)) == 180) 
+            if all(abs(obj.bbox(1,:)) == 180)
                 % for global mesh make it cyclical
                 hh_m = [hh_m(end,:); hh_m; hh_m(1,:)];
             end
-            hfun = reshape(hh_m',[numel(hh_m),1]); 
+            hfun = reshape(hh_m',[numel(hh_m),1]);
 
             dx = obj.h0*cosd(min(yg(1,:),85)); % for gradient function
             dy = obj.h0;                       % for gradient function
-            
+
             % make g a function of space
             dmy     = xg*0 ;
             for param = obj.g'
@@ -895,19 +895,19 @@ classdef edgefx
                     lim  = param(1);
                     dp1  = param(2);
                     dp2  = param(3);
-                    
+
                     limidx = (tmpz < dp1 & tmpz > dp2) ;
-                    
+
                     dmy( limidx ) = lim;
                 end
             end
-            if all(abs(obj.bbox(1,:)) == 180) 
+            if all(abs(obj.bbox(1,:)) == 180)
                 % for global mesh make it cyclical
                 dmy = [dmy(end,:); dmy; dmy(1,:)];
             end
-            fdfdx = reshape(dmy',[numel(dmy),1]); 
-            clearvars dmy; 
-            
+            fdfdx = reshape(dmy',[numel(dmy),1]);
+            clearvars dmy;
+
             [hfun,flag] = limgradStruct(obj.ny,dx,dy,hfun,...
                 fdfdx,sqrt(length(hfun)));
             if flag == 1
@@ -919,12 +919,12 @@ classdef edgefx
             % reshape it back
             hh_m = reshape(hfun,obj.ny,[])';
             clearvars hfun fdfdx
-            if all(abs(obj.bbox(1,:)) == 180) 
+            if all(abs(obj.bbox(1,:)) == 180)
                 % for global mesh make it cyclical
                 hh_m = hh_m(2:end-1,:);
                 hh_m(end,:) = hh_m(1,:);
             end
-            
+
             % Limit CFL if dt >= 0, dt = 0 finds dt automatically.
             if obj.dt(1) >= 0
                 if isempty(feat.Fb)
@@ -936,14 +936,14 @@ classdef edgefx
                 % Limit the minimum depth to 1 m (ignore overland)
                 tmpz(tmpz > - 1) = -1;
                 u = sqrt(grav*abs(tmpz)) + sqrt(grav./abs(tmpz));
-                
+
                 % Desired timestep to bound edgefx
                 desDt = obj.dt(1);
                 if isnan(desDt)
                     disp('No timestep enforcement due to no distance function')
                 end
-                
-                % Determine Courant min. and max. bounds  
+
+                % Determine Courant min. and max. bounds
                 if length(obj.dt) < 2
                     % default behavior if no bounds are passed
                     % for explicit type schemes we ensure the maxCr is
@@ -951,63 +951,66 @@ classdef edgefx
                     minCr = eps; % Cannot be zero!!!
                     maxCr = 0.5;
                 elseif length(obj.dt) == 2
-                    % minimum Courant number bound 
-                    minCr = obj.dt(2); 
-                    maxCr = inf; 
-                elseif length(obj.dt) == 3 
+                    if obj.dt(1)==0.0
+                        error('dt = 0 is only intended for restricting the upper bound of Cr')
+                    end
+                    % minimum Courant number bound
+                    minCr = obj.dt(2);
+                    maxCr = inf;
+                elseif length(obj.dt) == 3
                     % minimum and maximum Courant bound
                     minCr = obj.dt(2);
                     maxCr = obj.dt(3);
                 else
                     error('Length of dt name-value pair should be <=3')
                 end
-                
+
                 if minCr > maxCr
                     error('MinCr is > MaxCr, please switch order in dt name value call')
                 end
-                
+
                 % Automatic timestep selection option (for ADCIRC models)
                 if desDt == 0
                     hh_d(hh_d < obj.h0) = obj.h0;
                     obj.dt = min(min(maxCr*hh_d./u));
                     desDt  = obj.dt;
                 end
-                
+
                 % Enforcement of Courant bounds in mesh size function
                 fprintf(1, [ ...
                     'Enforcing timestep of ',num2str(desDt),' seconds ', ...
                     'with Courant number bounds of ',num2str(minCr),' to ',num2str(maxCr),'\n', ...
                     ] ) ;
-                
-                
+
+
                 Cr = (desDt*u)./hh_m; % Courant number for given desDt for mesh size variations
-                
+
                 % resolution that meets max. Cr. criteria for desDt
                 dxn_min = u*desDt/maxCr;
                 % resolution that meets min. Cr. criteria for desDt
                 dxn_max = u*desDt/minCr;
-                
+
                 % resolve min. Cr violations
                 hh_m( Cr <= minCr) = dxn_max( Cr <= minCr); %--in planar metres
-                
+
                 % resolve max. Cr violations
                 hh_m( Cr > maxCr) = dxn_min( Cr > maxCr);   %--in planar metres
-                
+
                 clear dxn_min dxn_max Cr
                 clear u hh_d tmpz
             end
 
-            
+
             obj.F = griddedInterpolant(xg,yg,hh_m,'linear','nearest');
-            
+
             clearvars xg yg
         end
-        
+
         function [xg,yg] = CreateStructGrid(obj)
             [xg,yg] = ndgrid(obj.x0y0(1) + (0:obj.nx-1)'*obj.gridspace, ...
                 obj.x0y0(2) + (0:obj.ny-1)'*obj.gridspace);
         end
-        
+
         function obj = release_memory(obj)
             % releases heavy components from data structures
             if isa(obj,'edgefx')
@@ -1017,46 +1020,46 @@ classdef edgefx
                 if ~isempty(obj.fsd)
                     obj.fsd = [];
                 end
-                
+
                 if ~isempty(obj.wld)
                     obj.wld = [];
                 end
-                
+
                 if ~isempty(obj.slpd)
                     obj.slpd = [];
                 end
-                
+
                 if ~isempty(obj.chd)
                     obj.chd = [];
                 end
-                
+
                 if ~isempty(obj.ch)
                     obj.ch = [];
                 end
-                
+
                 if ~isempty(obj.hhd)
                     obj.hhd = [];
                 end
-                
+
                 if ~isempty(obj.boudist)
                     obj.boudist = [];
                 end
-                
+
                 if ~isempty(obj.Channels)
                     obj.Channels = [];
                 end
-                
-                if ~isempty(obj.ch) 
+
+                if ~isempty(obj.ch)
                    obj.ch = [];
                 end
-                
-                if ~isempty(obj.boudist) 
-                   obj.boudist = []; 
+
+                if ~isempty(obj.boudist)
+                   obj.boudist = [];
                 end
             end
         end
-        
-        
+
+
     end
-    
+
 end

--- a/Examples/Example_3_ECGC.m
+++ b/Examples/Example_3_ECGC.m
@@ -23,7 +23,7 @@ R         = 3; 			        % Number of elements to resolve feature.
   
 %% STEP 2: specify geographical datasets and process the geographical data
 %% to be used later with other OceanMesh classes...
-dem       = 'SRTM15+V2.nc';
+dem       = 'SRTM15+V2.1.nc';
 coastline = 'GSHHS_f_L1';
 gdat1 = geodata('shp',coastline,'dem',dem,'h0',min_el,...
                 'bbox',bbox);


### PR DESCRIPTION
The automatic selection of the numerically stable timestep for which to CFL limit the mesh sizing function should be based on the `max_cr` not the `min_cr`. 

This appears to fix #114 with a mesh that should be numerically stable at a timestep of roughly 1.34 seconds because of the high resolution zone near New York, e.g., 

```
Enforcing timestep of 1.1134 seconds with Courant number bounds of 2.2204e-16 to 0.5
```
The outer patch by itself is theoretically stable with: 

```
Enforcing timestep of 6.2979 seconds with Courant number bounds of 2.2204e-16 to 0.5
```
<img width="1440" alt="Screen Shot 2020-09-12 at 1 38 30 PM" src="https://user-images.githubusercontent.com/18619644/93000276-b774a680-f4fd-11ea-86bd-4a734d1d6464.png">



