### PR TITLE
turn off 3d shapefile reading by default

### DIFF
--- a/@geodata/geodata.m
+++ b/@geodata/geodata.m
@@ -57,6 +57,7 @@ classdef geodata
         pslg % piecewise liner straight line graph
         spacing = 2.0 ; %Relative spacing along polygon, large effect on computational efficiency of signed distance.
         gridspace
+        shapefile_3d % if the shapefile has a height attribute
     end
     
     methods
@@ -75,7 +76,6 @@ classdef geodata
             %addOptional(p,'weirs',defval);
             %addOptional(p,'pslg',defval);
             %addOptional(p,'boubox',defval);
-            %addOptional(p,'window',defval);
             
             % Check for m_map dir
             M_MAP_EXISTS=0 ;
@@ -119,6 +119,7 @@ classdef geodata
             addOptional(p,'pslg',defval);
             addOptional(p,'boubox',defval);
             addOptional(p,'window',defval);
+            addOptional(p,'shapefile_3d',defval);
             
             % parse the inputs
             parse(p,varargin{:});
@@ -202,6 +203,8 @@ classdef geodata
                             % Default value
                             obj.window = 5;
                         end
+                    case('shapefile_3d')
+                         obj.shapefile_3d = inp.(fields{i}) ;
                     case('weirs')
                         if ~iscell(inp.(fields{i})) && ~isstruct(inp.(fields{i})) && inp.(fields{i})==0, continue; end
                         if ~iscell(inp.(fields{i})) && ~isstruct(inp.(fields{i}))
@@ -321,7 +324,7 @@ classdef geodata
                 end
                 
                 polygon_struct = Read_shapefile( obj.contourfile, [], ...
-                    obj.bbox, obj.gridspace, obj.boubox, 0 );
+                    obj.bbox, obj.gridspace, obj.boubox, 0, obj.shapefile_3d);
                 
                 % Unpack data from function Read_Shapefile()s
                 obj.outer     = polygon_struct.outer;

--- a/@geodata/private/Read_shapefile.m
+++ b/@geodata/private/Read_shapefile.m
@@ -1,5 +1,5 @@
 function polygon_struct = Read_shapefile( finputname, polygon, bbox, ...
-                                          h0, boubox, plot_on )
+                                          h0, boubox, plot_on, shapefile_3d)
 % Read_shapefile: Reads a shapefile or a NaN-delimited vector
 % containing polygons and/or segments in the the desired region
 % of interest. Classifies the vector data as either a
@@ -174,6 +174,9 @@ for i = 1 : size(tmpC,1)
         % using m_shaperead
         points = tmpC{i,1}(1:end,:) ;
         if size(points,2) == 3
+            points = points(:,1:2);
+        end
+        if shapefile_3d
             % if 3-D shapefile
             height = points(:,3); 
             points = points(:,1:2); 


### PR DESCRIPTION
* If a shapefile has a height (for whatever reason), previously it would trigger a very expensive set of operations on it that were invented for GLOCOFS and not for typical mesh generation. 
* This PR deactivates this behavior when a 3D shapefile is detected and lets the user give an option to geodata to turn it on `shapefile_3d` (0,1 boolean)