### PR TITLE
fixing the cell-averaging interp option

### DIFF
--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -314,7 +314,6 @@ classdef msh
             if nargin < 4
                 projtype = [] ;
             end
-            np_g = length(obj.p) ;
             fsz = 12; % default font size
             bgc = [1 1 1]; % default background color
             numticks = 10; % default num of ticks
@@ -983,8 +982,12 @@ classdef msh
             %                         interpolated region
             %
             %   ignoreOL - = 0 [default]: interpolate data without masking overland
-            %              = 1: Mask overland data which may help for seabed-only interpolation
-
+            %              = 1          : Mask overland data which may help for seabed-only interpolation
+            %     invert - = 0          : does not invert values of the dem
+            %                             (i.e., keeps the sign of the topography the same as the dem)
+            %              = 1 [default]: inverts the values of the dem
+            %                             (underwater is positive depth)
+            
             % if give cell of geodata or dems then interpolate all
             if iscell(geodata) || isstring(geodata)
                 for i = 1:length(geodata)
@@ -1001,6 +1004,19 @@ classdef msh
                     obj = GridData(geodata,obj,varargin);
                 end
             end
+            % Inverting if necessary
+            invert = 1;
+            tI = find(strcmp(varargin,'invert'));
+            if ~isempty(tI)
+                invert = varargin{tI+1};
+            end
+            % the output from GridData is underwater positive value so no
+            % inversion means flipping back
+            if ~invert
+                obj.b = -obj.b;
+            end
+            
+            % Checking the data...
             type = 'all';
             tI = find(strcmp(varargin,'type'));
             if ~isempty(tI)

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -473,11 +473,7 @@ classdef msh
                     if logaxis
                         q = log10(max(1,abs(obj.b))); % plot on log scale
                     else
-                        if exist('demcmap','file')
-                            q = -obj.b;
-                        else
-                            q = obj.b;
-                        end
+                        q = obj.b;
                     end
                     if proj
                         if mesh
@@ -497,11 +493,7 @@ classdef msh
                     if logaxis
                         cmocean('deep',numticks(1)-1);
                     else
-                        if exist('demcmap','file')
-                           demcmap(q);
-                        else
-                            cmocean('topo','pivot',min(max(q),pivot));
-                        end
+                        cmocean('topo','pivot',min(max(q),pivot));
                     end
                     cb = colorbar;
                     if logaxis

--- a/@msh/private/GridData.m
+++ b/@msh/private/GridData.m
@@ -220,7 +220,7 @@ xt = [obj.p(obj.t(:,1),1) obj.p(obj.t(:,2),1) ...
       obj.p(obj.t(:,3),1) obj.p(obj.t(:,1),1)];
 dxt = diff(xt,[],2);
 tt = obj.t;
-tt(abs(dxt(:,1)) > 180 | abs(dxt(:,2)) > 180 |  abs(dxt(:,2)) > 180,:) = [];
+tt(abs(dxt(:,1)) > 180 | abs(dxt(:,2)) > 180 |  abs(dxt(:,3)) > 180,:) = [];
 
 % Do this once;
 vtoe_o = VertToEle(tt); %find connecting elements to each node

--- a/README.md
+++ b/README.md
@@ -133,12 +133,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   made them required to have a 3d shapefiles.
 - plotting `gdat` with no shoreline. 
 - plotting a mesh's bathymetry with a non-zero datum using cmocean.
+- cell-averaging interpolation method in msh.interp fixed for unequal lon-lat DEM grid spacings
 
 ### Added
 - Ability to use the TPXO9 Atlas for the tidal bcs and sponge (inside tidal_data_to_ob.m and Calc_Sponge.m) by using '**' wildcards in place of the constituent name within the tidal atlas filename (the atlas has an individual file for each constituent).
 - Introducing 'auto_outer' option for the make_bc msh method which populates the bc for the outermost mesh boundary polygon (ignores islands)
 - Changelog to README
 - "mapMeshProperties" msh method ports over mesh properties for a mesh subset
+- 'invert' option in the msh.interp method to turn off the DEM value inversion typically performed
 
 ### Changed
 - for the make_bc msh method 'auto'/'auto_outer' options, allowing for the 'depth' method of classification to use the interpolated depths on the mesh if gdat is empty. 

--- a/utilities/FindLinearIdx.m
+++ b/utilities/FindLinearIdx.m
@@ -3,6 +3,7 @@ function [IX,IX1,IX2] = FindLinearIdx(x,y,lon,lat)
 % from a matrix of x-locations X and y-locations Y of both size nx columns and ny rows.
 % lon and lat must be matrices created by ndgrid. 
 % kjr, 20171210 chl, und.
+% wjp, 20201120 making sure dx and dy can be different
 ny = size(lon,1);
 nx = size(lon,2);
 np = numel(x);
@@ -10,11 +11,13 @@ np = numel(x);
 X = reshape(lon,[],1);
 Y = reshape(lat,[],1);
 
+% Get the grid spacing in x and y directions 
+% (trying both directions so could be meshgrid or ndgrid format)
+dx  = max(abs(lon(2,1)-lon(1,1)),abs(lon(1,2)-lon(1,1)));
+dy  = max(abs(lat(1,2)-lat(1,1)),abs(lat(2,1)-lat(1,1)));
+
 x = x(:);
 y = y(:);
-
-dx  = X(2)-X(1);
-dy  = dx;
 
 IX1 = (x-X(1))./dx + 1;
 IX2 = (y-Y(1))./dy + 1;


### PR DESCRIPTION
- unequal dx and dy in the DEM lead to problems with the FindLinearIdx routine.  So fixing this routine to make sure dx and dy can be different.
- adding the 'invert' option to turn off the DEM value inversion usually peformed to make underwater positive.

See the issue #147 that brought this to our attention. 
Here is the new result using "fixed" interp:
```
m = m.interp('Topo_Bath_100x100_WGS.nc','interp','CA','invert',0);
plot(m,'b')
demcmap([-200 -100])
```
![image](https://user-images.githubusercontent.com/21131934/100917485-d7808a00-349c-11eb-9166-f90314a984df.png)

original dem:
![image](https://user-images.githubusercontent.com/21131934/100917714-22020680-349d-11eb-936f-cc4bca4761b3.png)
