### PR TITLE
bug fixes for plotting and mapping boundaries

### DIFF
--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -493,7 +493,7 @@ classdef msh
                     if logaxis
                         cmocean('deep',numticks(1)-1);
                     else
-                        cmocean('topo','pivot',min(max(q),pivot));
+                        cmocean('-topo','pivot',min(max(q),pivot));
                     end
                     cb = colorbar;
                     if logaxis
@@ -794,7 +794,8 @@ classdef msh
                         end
                         defval  = obj.f13.defval.Atr(ii).Val;
                         userval = obj.f13.userval.Atr(ii).Val;
-                        values = obj.p(:,1)*0 + defval';
+                        defval = reshape(defval,1,[]);
+                        values = obj.p(:,1)*0 + defval;
                         values(userval(1,:),:) = userval(2:end,:)';
                         % just take the inf norm
                         values = max(values,[],2);
@@ -4017,7 +4018,8 @@ classdef msh
                     % Only keep idx_old that is common to ind and map to ind
                     [~,~,idx_new] = intersect(idx_old,ind,'stable');
                     % if a polygon
-                    if length(idx_new) == length(idx_old)-1 && idx_old(end) == idx_old(1)
+                    if ~isempty(idx_new) && ...
+                        length(idx_new) == length(idx_old)-1 && idx_old(end) == idx_old(1)
                         idx_new(end+1) = idx_new(1);
                     end
                     % Get the new length of this boundary
@@ -4043,7 +4045,8 @@ classdef msh
                     % Only keep idx_old that is common to ind and map to ind
                     [~,~,idx_new] = intersect(idx_old,ind,'stable');
                     % if a polygon
-                    if length(idx_new) == length(idx_old)-1 && idx_old(end) == idx_old(1)
+                    if ~isempty(idx_new) && ...
+                       length(idx_new) == length(idx_old)-1 && idx_old(end) == idx_old(1)
                         idx_new(end+1) = idx_new(1);
                     end
                     % Get the new length of this boundary

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -360,7 +360,7 @@ classdef msh
                 end
                 % Get a subset given by bou
                 [obj,kept] = extract_subdomain(obj,bou,[],[],0);
-                obj = mapMeshProperties(obj,kept);
+                obj = map_mesh_properties(obj,kept);
             end
 
             % Set up projected space
@@ -2558,7 +2558,7 @@ classdef msh
             % e.g., b, bx, by, f13, f24, f5354 dat
             [obj.p,obj.t,pix] = fixmesh(obj.p,obj.t);
             % carry over...
-            obj = mapMeshProperties(obj,pix);
+            obj = map_mesh_properties(obj,pix);
         end
 
 
@@ -3992,8 +3992,8 @@ classdef msh
             boundary = cell2mat(boundary');
         end
 
-        function obj = mapMeshProperties(obj,ind)
-            % obj = mapMeshProperties(obj,ind)
+        function obj = map_mesh_properties(obj,ind)
+            % obj = map_mesh_properties(obj,ind)
             % Map properties of a msh obj given a subset of integers, 'ind'.
             % Assumes that the p and t components of the mesh have already
             % been changed

--- a/utilities/extract_subdomain.m
+++ b/utilities/extract_subdomain.m
@@ -17,7 +17,7 @@ function [obj,ind] = extract_subdomain(obj,bou,keep_inverse,centroid,nscreen)
 % Outputs:
 % obj: the subset mesh obj (only p and t, properties untouched)
 % ind: an array of indices that can be used to map the mesh properties to
-% the output mesh subset with a subsequent call to "mapMeshProperties". 
+% the output mesh subset with a subsequent call to "map_mesh_properties". 
 %
 p = obj.p; t = obj.t; 
 if nargin == 1 || (nargin == 3 && isempty(bou))
@@ -82,7 +82,7 @@ if nscreen
     % Displaying notice for mapping mesh properties
     disp('NOTICE: Only p and t have been subset.')
     disp('  To map mesh properties to the subset output the ind array and call: ')
-    disp('  mesh_obj = mapMeshProperties(mesh_obj,ind)')
+    disp('  mesh_obj = map_mesh_properties(mesh_obj,ind)')
 end
 % EOF
 end


### PR DESCRIPTION
- cmocean with topo should usually be the inverse if orientation is positive downward
- if the boundary was one node long then would error in the mapMeshProperties function
- for plotting arbitrary f13 attribute, when defval has length > 1 the vector needs to a 1 x N array