### PR TITLE
Example 12 -> Example 11 

### DIFF
--- a/Examples/Example_11_Remeshing_Patches.m
+++ b/Examples/Example_11_Remeshing_Patches.m
@@ -1,8 +1,11 @@
-% Example_12_Remeshing_Patches.m
+% Example_11_Remeshing_Patches.m
 % 
 % This example highlights a workflow on how to re-mesh and insert patches
 % using user defined mesh sizing functions from OceanMesh2D preserving
 % the pathces subdomain boundaries exactly.
+%
+% This requires the mesh2d package to be on the path.
+% https://github.com/dengwirda/mesh2d
 %
 % By Keith Roberts, 2020, USP, Brazil.
 

--- a/Examples/Example_11_Remeshing_Patches.m
+++ b/Examples/Example_11_Remeshing_Patches.m
@@ -35,6 +35,8 @@ mshopts = mshopts.build;
 %% STEP 5: Plot it and write a triangulation fort.14 compliant file to disk.
 % Get out the msh class and put on nodestrings
 m = mshopts.grd;
+% Interpolate topobathy data onto the vertices of the mesh.
+m = interp(m,'SRTM15+V2.1.nc'); 
 %% Extract the region which you want to remesh
 % For the purpose of this example, we have drawn a random polygon on top
 % of the mesh for which we would like to remesh.
@@ -46,8 +48,8 @@ hole = [  172.7361  -44.0332
   173.5714  -43.6053
   173.0915  -44.1310];
 % This extracts the parent mesh but with the polygon removed.
-subdomain = extract_subdomain(m,hole);
-% Visualzie it
+subdomain = extract_subdomain(m,hole); 
+% Visualize the subdomain
 plot(subdomain);
 %% Get the boundary of this hole in the mesh
 % Follow the instructions in the title of the plot and click on one of the 
@@ -60,7 +62,11 @@ poly = get_poly(subdomain);
 subdomain_new = mesh2dgen(poly{1},fh); 
 %% Merge the patch in
 % Remove the subdomain from the parent mesh
-m = extract_subdomain(m,hole,1);
+m_w_hole = extract_subdomain(m,hole,1);
 % Since the boundaries match identically, this is a trivial merge.
-m_new = plus(subdomain_new, m, 'match');
-plot(m_new); hold on; plot(poly{1}(1:end-1,1),poly{1}(1:end-1,2),'r-','linewi',3);
+m_new = plus(subdomain_new, m_w_hole, 'match');
+% Use a trivial nearest neighbor interpolation to put the bathy back on 
+% the new mesh
+ind = nearest_neighbor_map(m, m_new);
+m_new.b = m.b(ind); 
+plot(m_new,'bmesh'); hold on; plot(poly{1}(1:end-1,1),poly{1}(1:end-1,2),'r-','linewi',3);

--- a/Examples/Example_11_Remeshing_Patches.m
+++ b/Examples/Example_11_Remeshing_Patches.m
@@ -8,13 +8,10 @@
 % https://github.com/dengwirda/mesh2d
 %
 % By Keith Roberts, 2020, USP, Brazil.
-
 clearvars; clc;
-
 addpath(genpath('../utilities/'))
 addpath(genpath('../datasets/'))
 addpath(genpath('../m_map/'))
-
 %% STEP 1: Here we mimic the steps that occurred in Example_1_NZ.m
 bbox = [166 176;		% lon_min lon_max
     -48 -40]; 		% lat_min lat_max
@@ -35,11 +32,9 @@ fh = edgefx('geodata',gdat,...
 % build the mesh...
 mshopts = meshgen('ef',fh,'bou',gdat,'plot_on',1,'nscreen',5,'proj','trans');
 mshopts = mshopts.build;
-
 %% STEP 5: Plot it and write a triangulation fort.14 compliant file to disk.
 % Get out the msh class and put on nodestrings
 m = mshopts.grd;
-
 %% Extract the region which you want to remesh
 % For the purpose of this example, we have drawn a random polygon on top
 % of the mesh for which we would like to remesh.
@@ -50,7 +45,6 @@ hole = [  172.7361  -44.0332
   174.5999  -45.1137
   173.5714  -43.6053
   173.0915  -44.1310];
-
 % This extracts the parent mesh but with the polygon removed.
 subdomain = extract_subdomain(m,hole);
 % Visualzie it
@@ -63,16 +57,10 @@ poly = get_poly(subdomain);
 % Using the polygon we just extracted (poly) and the original mesh size 
 % function (fh), remesh this hole with Delaunay refinement mesh2d. 
 % Recall poly is a cell-array so pass it the hole you want to mesh!
-
 subdomain_new = mesh2dgen(poly{1},fh); 
-
 %% Merge the patch in
-
 % Remove the subdomain from the parent mesh
 m = extract_subdomain(m,hole,1);
-
 % Since the boundaries match identically, this is a trivial merge.
 m_new = plus(subdomain_new, m, 'match');
-
-
 plot(m_new); hold on; plot(poly{1}(1:end-1,1),poly{1}(1:end-1,2),'r-','linewi',3);

--- a/utilities/nearest_neighbor_map.m
+++ b/utilities/nearest_neighbor_map.m
@@ -1,0 +1,16 @@
+function ind = nearest_neighbor_map(m_old, m_new)
+% Determine the indices of the nearest neighbors from m_old.p to m_new.p 
+% to do for example a trivial transfer of nodal attributes or bathymetry. 
+%
+% Inputs
+% m_old: the old mesh object 
+% m_new: the new mesh object
+%
+% Output
+% The indices of points from m_old to m_new 
+%
+% Example
+% Transfer bathymetry data from one grid to a new one.
+% m_new.b = m_old.b(ind)
+ind = ourKNNsearch(m_old.p',m_new.p',1);
+end


### PR DESCRIPTION
* typo in example name.
* link to package that needs to be downloaded to run the example.
* add `nearest_neighbor_map` to get indices of vertex neighbors in the case of minor connectivity changes. 
* update example to reflect the transfer of data between a mesh object that's undergone some kind of minor connectivity change.