### PR TITLE
Clean interface improvements

### DIFF
--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -46,7 +46,7 @@ classdef msh
         title % mesh title
         p  % vertices
         t  % triangles
-        b  % bathymetry
+        b  % bathy
         bd % land boundaries
         op % open boundaries
         bx % slope of bathy in x direction
@@ -1094,11 +1094,11 @@ classdef msh
             % Reduce the mesh connectivity to maximum of con-1
             % May not always work without error
             if opt.con > 6
-                %try
+                try
                     obj = bound_con_int(obj,opt.con);
-                %catch
-                 %   warning('Could not reduce connectivity mesh');
-                %end
+                catch
+                    warning('Could not reduce connectivity mesh');
+                end
             end
 
             % Now do the smoothing if required

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -984,7 +984,7 @@ classdef msh
             %process categorical cleaning options
             if any(strcmp(varargin,'passive'))
                 disp('Employing passive option')
-                opt.db = 0.1; opt.ds = 0; opt.con = 10; opt.djc = 0;
+                opt.db = 0.1; opt.ds = 0; opt.con = 0; opt.djc = 0;
                 opt.sc_maxit = 0; opt.mqa = 1e-4; opt.renum = 0;
                 varargin(strcmp(varargin,'passive')) = [];
             elseif any(strcmp(varargin,'aggressive'))

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -3921,7 +3921,7 @@ classdef msh
             % Name value pairs specified.
             % Parse other varargin
             ind = [];
-            m_old = [];
+            m_old = obj; 
             for kk = 1:2:length(varargin)
                 if strcmp(varargin{kk},'msh_old')
                     m_old = varargin{kk+1};
@@ -3932,15 +3932,15 @@ classdef msh
             if isempty(ind)
                 ind = nearest_neighbor_map(m_old, obj);
             end
-            if ~isempty(obj.b)
-                obj.b = obj.b(ind);
+            if ~isempty(m_old.b)
+                obj.b = m_old.b(ind);
             end
             % topographic gradients
             if ~isempty(obj.bx)
-                obj.bx = obj.bx(ind);
+                obj.bx = m_old.bx(ind);
             end
             if ~isempty(obj.by)
-                obj.by = obj.by(ind);
+                obj.by = m_old.by(ind);
             end
             % open boundary info
             if ~isempty(obj.op) && obj.op.nope > 0
@@ -4018,8 +4018,8 @@ classdef msh
                 obj.f13.NumOfNodes = length(ind);
                 for att = 1:obj.f13.nAttr
                     % Get the old index for this attribute
-                    idx_old = obj.f13.userval.Atr(att).Val(1,:);
-                    val_old = obj.f13.userval.Atr(att).Val(2:end,:);
+                    idx_old = m_old.f13.userval.Atr(att).Val(1,:);
+                    val_old = m_old.f13.userval.Atr(att).Val(2:end,:);
                     % Only keep idx and val that is common to ind and map to ind
                     [~,ind_new,idx_new] = intersect(idx_old,ind);
                     val_new = val_old(:,ind_new);
@@ -4030,11 +4030,11 @@ classdef msh
             end
             % f24
             if ~isempty(obj.f24)
-                obj.f24.Val = obj.f24.Val(:,:,ind);
+                obj.f24.Val = m_old.f24.Val(:,:,ind);
             end
             % f5354
             if ~isempty(obj.f5354)
-                idx_old = obj.f5354.nodes;
+                idx_old = m_old.f5354.nodes;
                 [~,idx_new] = intersect(idx_old,ind);
                 obj.f5354.nodes = idx_new;
             end

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -1093,11 +1093,11 @@ classdef msh
             % Reduce the mesh connectivity to maximum of con-1
             % May not always work without error
             if opt.con > 6
-                try
+                %try
                     obj = bound_con_int(obj,opt.con);
-                catch
-                    warning('Could not reduce connectivity mesh');
-                end
+                %catch
+                 %   warning('Could not reduce connectivity mesh');
+                %end
             end
 
             % Now do the smoothing if required
@@ -4023,6 +4023,22 @@ classdef msh
                     % Only keep idx and val that is common to ind and map to ind
                     [~,ind_new,idx_new] = intersect(idx_old,ind);
                     val_new = val_old(:,ind_new);
+                    
+                    % find indices of new nodes
+                    [~,ind_added] = setdiff(obj.p,m_old.p,'rows');
+                    if ~isempty(ind_added)
+                        defval  = m_old.f13.defval.Atr(att).Val;
+                        userval = m_old.f13.userval.Atr(att).Val;
+                        defval = reshape(defval,1,[]);
+                        values = obj.p(:,1)*0 + defval;
+                        values(userval(1,:),:) = userval(2:end,:)';
+                        % for the new indices give the closest value in m_old
+                        % for any given nodal attribute
+                        tmp = ourKNNsearch(m_old.p',obj.p(ind_added,:)',1);
+                        val_new2 = values(tmp,:); 
+                        idx_new = [idx_new; ind_added];
+                        val_new = [val_new'; val_new2]'; 
+                    end                    
                     % Put the uservalues back into f13 struct
                     obj.f13.userval.Atr(att).Val = [idx_new'; val_new];
                     obj.f13.userval.Atr(att).usernumnodes = length(idx_new);

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## Added
 - `mesh2d` interface improvements to filter small polygons.
 - Support for creation of `fort.20` files for forcing rivers by @Jiangchao3
+- Mesh "cleaning" modes moderate and aggressive transfer nodal attributes via improvements to `msh.map_mesh_properties`
 
 ## Changed
 - `msh.plot()` overhaul. All options specified via kwarg.


### PR DESCRIPTION
* this is a breaking change that will need some time and extensive testing to land
* addresses #180 
* `msh.clean()`'s passive mode does not apply nodal valency reduction now. 
* TODO: better handling of nodal attribute migration when applying moderate and aggressive cleaning.