### PR TITLE
Patch bug-fix to the "matche" option of the msh.plus() function.

### DIFF
--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -2217,23 +2217,25 @@ classdef msh
                     %% can be extracted and then obj1, obj2 concentated together
                     % extract the inner region of obj1 (inset) from obj2 (base)
                     % assuming that the inset fits perfectly in the base
-                    obj1o = obj1; obj2o = obj2; 
+                    obj1o = obj1; 
                     if extract
                         [p1(:,1),p1(:,2)] = m_ll2xy(p1(:,1),p1(:,2)) ;
                         [p2(:,1),p2(:,2)] = m_ll2xy(p2(:,1),p2(:,2)) ;
                         obj1.p = p1; obj2.p = p2;
                         bou = get_boundary_of_mesh(obj1,1);
                         [~,outer] = max(cellfun(@length,bou));
-                        obj2 = extract_subdomain(obj2,bou{outer},...
+                        [obj2,ind] = extract_subdomain(obj2,bou{outer},...
                                            'centroid',1,'keep_inverse',1);
+                        obj2 = map_mesh_properties(obj2,'ind',ind);
                         [obj2.p(:,1),obj2.p(:,2)] = m_xy2ll(obj2.p(:,1),obj2.p(:,2));
                         obj2 = obj2.clean(cleanargin);
+                        clear ind
                     end
                     % concatenate
                     m1 = cat(obj1o,obj2);
                     merge = msh(); merge.p = m1.p; merge.t = m1.t;
-                    obj1 = obj1o; obj2 = obj2o;
-                    clear m1 obj1o obj2o
+                    obj1 = obj1o;
+                    clear m1 obj1o
                 otherwise
                     %% Abitrary non-matching overlapping meshes
                     % Project both meshes into the space of the global mesh

--- a/utilities/extract_subdomain.m
+++ b/utilities/extract_subdomain.m
@@ -1,5 +1,5 @@
-function [obj,ind] = extract_subdomain(obj,bou,varargin)
-% [obj,ind] = extract_subdomain(obj,bou,varargin)
+function [obj,ind,in] = extract_subdomain(obj,bou,varargin)
+% [obj,ind,in] = extract_subdomain(obj,bou,varargin)
 %
 % Inputs:
 % bou: a bbox, i.e.: [lon min, lon_max;
@@ -25,7 +25,9 @@ function [obj,ind] = extract_subdomain(obj,bou,varargin)
 % Outputs:
 % obj: the subset mesh obj (only p and t, properties untouched)
 % ind: an array of indices that can be used to map the mesh properties to
-% the output mesh subset with a subsequent call to "map_mesh_properties".
+%      the output mesh subset with a subsequent call to "map_mesh_properties".
+%  in: the logical array of elements within the given boundary
+%      used to perform the subsetting 
 %
 keep_inverse = 0 ;
 keep_numbering = 0 ;


### PR DESCRIPTION
- The original obj2 mesh was being using to map over msh properties to the merged mesh instead of the subsetted obj2 msh. This has been corrected.
- Added optional output of 'in' (logical array of elements within the boundary) to extract_subdomain