### PR TITLE
deleting bcs

### DIFF
--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -1266,7 +1266,8 @@ classdef msh
             % ---------
             % 'delete' - deletes a user-clicked boundary condition from msh.
             % varargins:
-            % none
+            % index of boundary to delete 
+
             if nargin < 2
                 error('Needs type: one of "auto", "outer", "inner", "delete", or "weirs"')
             end
@@ -1801,8 +1802,7 @@ classdef msh
                         dir,obj.op,obj.bd); %<--updates op and bd.
 
                 case('delete')
-                    % have the user select the nodestring '
-                    plot(obj,'type','bd','proj','none') ;
+                    
                     temp = obj.bd.nbvv;
                     bounodes=obj.bd.nbvv ;
                     idx=sum(bounodes~=0);
@@ -1815,24 +1815,39 @@ classdef msh
                         k = k + 1 ;
                         bounodes(idx2(i):idx2(i+1)-1,2) = k ;
                     end
-
-                    dcm_obj = datacursormode(gcf);
-                    title('use data cursor to select nodestring to be deleted');
-                    pause
-                    c_info = getCursorInfo(dcm_obj);
-                    [tmp(:,1),tmp(:,2)]=m_ll2xy(boupts(:,1),boupts(:,2));
-                    idx3 = ourKNNsearch(boupts',c_info.Position',1)  ;
-                    del = bounodes(idx3,2) ;  %<- get the nodestring index
-                    pltid = temp(:,del) ; pltid(pltid==0)=[] ;
-                    hold on; m_plot(obj.p(pltid,1),obj.p(pltid,2),'r-','linewi',2) ;
-                    disp(['Delete boundary with index ',num2str(del),'?']) ;
-                    pause
+                    
+                    if isempty(varargin)
+                        % have the user select the nodestring '
+                        plot(obj,'type','bd','proj','none') ;
+              
+                        
+                        dcm_obj = datacursormode(gcf);
+                        title('use data cursor to select nodestring to be deleted');
+                        pause
+                        c_info = getCursorInfo(dcm_obj);
+                        [tmp(:,1),tmp(:,2)]=m_ll2xy(boupts(:,1),boupts(:,2));
+                        idx3 = ourKNNsearch(boupts',c_info.Position',1)  ;
+                        del = bounodes(idx3,2) ;  %<- get the nodestring index
+                        pltid = temp(:,del) ; pltid(pltid==0)=[] ;
+                        hold on; m_plot(obj.p(pltid,1),obj.p(pltid,2),'r-','linewi',2) ;
+                    else
+                        del = varargin{1}; 
+                    end
+                    disp(['Deleting boundary with index ',num2str(del)]) ;
+                    
                     obj.bd.nbvv(:,del)=[];
+                    if ~isempty(obj.bd.ibconn)
+                        obj.bd.ibconn(:,del)=[];
+                        obj.bd.barinht(:,del)=[]; 
+                        obj.bd.barincfsb(:,del)=[];
+                        obj.bd.barincfsp(:,del)=[];
+                    end
                     num_delnodes = idx(del) ;
                     obj.bd.nbou = obj.bd.nbou - 1 ;
                     obj.bd.nvell(del)=[] ;
                     obj.bd.ibtype(del)=[] ;
                     obj.bd.nvel = obj.bd.nvel - num_delnodes ;
+
 
                 case('weirs')
                     if isempty(varargin)

--- a/README.md
+++ b/README.md
@@ -141,7 +141,10 @@ Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Unreleased
-- None
+## Added 
+- Deleting boundary conditions by specifyng their indices in `msh.object.bd` field. See https://github.com/CHLNDDEV/OceanMesh2D/pull/205
+## Fixed
+- Correctly deleting weirs from boundary object through `make_bc` delete method. See https://github.com/CHLNDDEV/OceanMesh2D/pull/205
 
 ### [4.0.0] - 2021-03-14
 ## Added


### PR DESCRIPTION
* improving `make_bc` delete method by enabling user to pass boundary index number without having to click on figure. 
* weirs are now correctly deleted from the `msh` object.