### PR TITLE
Precise nearest neighbor mapping for extremely close points (e.g., weirs/levess)

### DIFF
--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -2566,7 +2566,7 @@ classdef msh
         end
 
         function obj = carryoverweirs(obj,obj1)
-            idx1 = ourKNNsearch(obj.p',obj1.p',1);
+            idx1 = nearest_neighbor_map(obj, obj1,'precise');
             if isempty(obj.bd)
                 obj.bd.nbou=0;
                 obj.bd.nvell=[];

--- a/@msh/private/GridData.m
+++ b/@msh/private/GridData.m
@@ -75,6 +75,7 @@ N    = 1 ;
 mindepth = -inf ; 
 maxdepth = +inf ; 
 rms_slope_calc = true;
+slope_calc = 'rms';
 if ~isempty(varargin)
     varargin=varargin{1} ; 
     names = {'K','type','interp','nan','N','mindepth','maxdepth','ignoreOL','slope_calc'};

--- a/utilities/Make_f24.m
+++ b/utilities/Make_f24.m
@@ -1,16 +1,19 @@
-function obj = Make_f24( obj, avisoloc, saldata )
-% obj = Make_f24( obj, avisoloc, saldata )
+function obj = Make_f24( obj, saldata, plot_on )
+% obj = Make_f24( obj, saldata, plot_on )
 % Takes a msh object and interpolates the global SAL term into the f24
 % struct
-% avisoloc is the directory where the saldata is located (netcdf files). 
+% Assumes that saldata is in the MATLAB path
 % The saldata required can be downloaded from:                                                          
 % saldata = 'FES2004' : Source at: ftp://ftp.legos.obs-mip.fr/pub/soa/...  
 %                                 maree/tide_model/global_solution/fes2004/           
 %                                                                         
 % saldata = 'FES2014' : Source at: ftp://ftp.legos.obs-mip.fr/pub/...
 %                                  FES2012-project/data/LSA/FES2014/             
-% 
-% by default saldata = 'FES2014' and avisoloc is the current directory
+% by default saldata = 'FES2014' 
+%
+% plot_on -  1/true: to plot and print F24 values for checking
+%            0/false: no plotting by default
+%
 % Created by William Pringle. July 11 2018 updated to Make_f## style             
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -19,11 +22,11 @@ if isempty(obj.f15)
           'with tidal potential information']) 
 end
 
-if nargin < 2
-   avisoloc = '';
-end
-if nargin < 3
+if nargin < 2 || isempty(saldata)
    saldata = 'FES2014'; 
+end
+if nargin < 3 || isempty(plot_on)
+   plot_on = false; 
 end
 
 ll0 = obj.f15.slam(1) ;
@@ -41,7 +44,7 @@ ntip = length(obj.f24.tiponame) ;
 
 % choose tidal database file names and directories
 database = strtrim(upper(saldata)) ;
-direc    = strtrim(avisoloc) ;
+direc    = '';
 
 % % Load tide grid data 
 if strcmp(database,'FES2004')
@@ -115,11 +118,14 @@ for icon = 1: ntip
     phs(phs < 0) = phs(phs < 0) + 360;
     
     % Plot interpolated results
-    figure(1); fastscatter(VX(:,1),VX(:,2),amp); 
-    title(obj.f24.tiponame{icon})
-    colorbar;
-    pause(2)
-    
+    if plot_on
+       figure(1); fastscatter(VX(:,1),VX(:,2),amp); 
+       colorbar;
+       constituent = obj.f24.tiponame{icon};
+       title(constituent)
+       print(['F24_' constituent '_check'],'-dpng')
+    end    
+
     % Put into the struct
     obj.f24.Val(icon,:,:) = [kvec'; amp'; phs']; 
 end

--- a/utilities/nearest_neighbor_map.m
+++ b/utilities/nearest_neighbor_map.m
@@ -1,10 +1,14 @@
-function ind = nearest_neighbor_map(m_old, m_new)
+function ind = nearest_neighbor_map(m_old, m_new, type)
+% ind = nearest_neighbor_map(m_old, m_new, type)
+%
 % Determine the indices of the nearest neighbors from m_old.p to m_new.p 
 % to do for example a trivial transfer of nodal attributes or bathymetry. 
 %
 % Inputs
 % m_old: the old mesh object 
 % m_new: the new mesh object
+% type (optional): 'approx' to use ourKNNsearch ANN wrapper
+%                  'precise' to use built in MATLAB knnsearch
 %
 % Output
 % The indices of points from m_old to m_new 
@@ -12,5 +16,23 @@ function ind = nearest_neighbor_map(m_old, m_new)
 % Example
 % Transfer bathymetry data from one grid to a new one.
 % m_new.b = m_old.b(ind)
-ind = ourKNNsearch(m_old.p',m_new.p',1);
+
+% checking type input
+if nargin < 3 || isempty(type)
+    type = 'approx';
+end
+% check that knnsearch built-in exists if precise selection, 
+% otherwise use approx
+if strcmp(type,'precise') && ~exist('knnsearch') 
+    type = 'approx';
+end
+
+if strcmp(type,'approx')
+   ind = ourKNNsearch(m_old.p',m_new.p',1);
+elseif strcmp(type,'precise')
+   ind = knnsearch(m_old.p,m_new.p); 
+else
+   error(['Unknown selection for type: ' type])
+end
+    
 end


### PR DESCRIPTION
adding precise option (calls Matlab's native knnsearch) in nearest_neighbor_map and calling in the carry over weirs routine since sometimes the weir points can be so close together that the precision of ANN ourKNNsearch fails while matlab's knnsearch works

I added a check for the presence of knnsearch in case the user doesn't have it. 