### PR TITLE
allowing user to set axis limits when plotting

### DIFF
--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -321,6 +321,8 @@ classdef msh
             %    v) 'pivot'   : value in meters for which to assume is datum when
             %                    plotting topo-bathymetry (default 0.0 m)
             %
+            %   axes_limits   : Force the axes limits to be bounded by what
+            %                   is passed in bbox.  
 
             fsz = 12; % default font size
             bgc = [1 1 1]; % default background color
@@ -328,6 +330,7 @@ classdef msh
             holdon = 0;
             pivot = 0.0; % assume datum is 0.0 m
             proj = 1;
+            axis_limits = []; % use mesh extents to determine plot extents
 
             projtype = []; 
             type = 'tri'; 
@@ -349,6 +352,8 @@ classdef msh
                     type = varargin{kk+1}; 
                 elseif strcmp(varargin{kk},'subdomain')
                     subdomain = varargin{kk+1}; 
+                elseif strcmp(varargin{kk},'axis_limits')
+                    axis_limits = varargin{kk+1}; 
                 end
             end
 
@@ -386,7 +391,7 @@ classdef msh
             end
 
             % Set up projected space
-            del = setProj(obj,proj,projtype) ;
+            del = setProj(obj,proj,projtype,0,axis_limits) ;
 
             if del
                 % This deletes any elements straddling the -180/180

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -321,7 +321,7 @@ classdef msh
             %    v) 'pivot'   : value in meters for which to assume is datum when
             %                    plotting topo-bathymetry (default 0.0 m)
             %
-            %   axis_limits   : Force the axes limits to be bounded by what
+            %   'axis_limits' : Force the axes limits to be bounded by what
             %                   is passed in bbox.  
 
             fsz = 12; % default font size

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -321,7 +321,7 @@ classdef msh
             %    v) 'pivot'   : value in meters for which to assume is datum when
             %                    plotting topo-bathymetry (default 0.0 m)
             %
-            %   axes_limits   : Force the axes limits to be bounded by what
+            %   axis_limits   : Force the axes limits to be bounded by what
             %                   is passed in bbox.  
 
             fsz = 12; % default font size

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Unreleased
 ## Added
 - Deleting boundary conditions by specifyng their indices in `msh.object.bd` field. See https://github.com/CHLNDDEV/OceanMesh2D/pull/205
+- Ability for user to set their own axis limits when plotting with `msh.plot()`. https://github.com/CHLNDDEV/OceanMesh2D/pull/224 
 ## Fixed
 - Correctly deleting weirs from boundary object through `make_bc` delete method. See https://github.com/CHLNDDEV/OceanMesh2D/pull/205
 - Array format fix for reading in ibtype and nvell from fort.14 file and when executing carry_over_weirs. See https://github.com/CHLNDDEV/OceanMesh2D/pull/206

--- a/Tests/TestECGC.m
+++ b/Tests/TestECGC.m
@@ -1,9 +1,10 @@
 % Run example 3 to test multi-scale meshing, bound_courant_number, and interp
-cd ..
+clearvars; clc
 
-addpath(genpath('utilities/'))
-addpath(genpath('datasets/'))
-addpath(genpath('m_map/'))
+addpath('..')
+addpath(genpath('../utilities/'))
+addpath(genpath('../datasets/'))
+addpath(genpath('../m_map/'))
 
 ERR_TOL = 0.05;
 ERR2_TOL = 0.01;

--- a/Tests/TestEleSizes.m
+++ b/Tests/TestEleSizes.m
@@ -1,11 +1,12 @@
 % Test size bounds with varying mesh gradation rates.
-cd ..
+clearvars; clc;
 
-addpath(genpath('utilities/'))
-addpath(genpath('datasets/'))
-addpath(genpath('m_map/'))
+addpath('..')
+addpath(genpath('../utilities/'))
+addpath(genpath('../datasets/'))
+addpath(genpath('../m_map/'))
 
-MIN_RESO_TOL = 100 ;
+RESO_TOL = 95; %percentage of resolution in bounds
 
 bbox = [166 176;		% lon_min lon_max
     -48 -40]; 		% lat_min lat_max
@@ -26,7 +27,7 @@ for i = 1 : 3 % for each grade
     m1 = mshopts.grd;
     
     [bars,barlen] = GetBarLengths(m1,0);
-    % sort bar lengths in ascending order
+    % sort bar lengths in descending order
     [barlen,IA] = sort(barlen,'descend');
     bars = bars(IA,:);
     % get the minimum bar length for each node
@@ -35,13 +36,13 @@ for i = 1 : 3 % for each grade
     d1 = NaN*m1.p(:,1); d2 = NaN*m1.p(:,1);
     d1(B1) = barlen(IB); d2(B2) = barlen(IC);
     reso = min(d1,d2);
-    
-    if abs(prctile(reso,5) - min_el) > MIN_RESO_TOL
-        error(['Minimum resolution does not match for grade ',num2str(grade(i)),'. Got ',...
-            num2str(prctile(reso,5)),' expecting 1e3 +- 100 m']);
+   
+    reso_in_bounds = 100*sum(reso > min_el & reso < max_el)/length(reso); 
+    if reso_in_bounds < RESO_TOL
+        error(['Resolution bounds does not match for grade ' num2str(grade(i)) ...
+               '. Got ' num2str(reso_in_bounds) '% of vertices with resolution in bounds']); 
         exit(1)
     end
-    disp(['Passed for ',num2str(grade(i)),'. Min. element size is ',num2str(prctile(reso,5))]); 
+    disp(['Passed for ' num2str(grade(i)) '. ' ...
+          num2str(reso_in_bounds) '% of vertices have resolution in bounds']); 
 end
-
-cd Tests/

--- a/Tests/TestInterp.m
+++ b/Tests/TestInterp.m
@@ -3,11 +3,13 @@
 % i)   constant dx = constant dy 
 % ii)  constant dx ~= constant dy 
 % iii) varying dx ~= varying dy
-cd ..
 
-addpath(genpath('utilities/'))
-addpath(genpath('datasets/'))
-addpath(genpath('m_map/'))
+clearvars; clc;
+
+addpath('..')
+addpath(genpath('../utilities/'))
+addpath(genpath('../datasets/'))
+addpath(genpath('../m_map/'))
 
 % add the geospatial data filenames
 coastline = 'GSHHS_f_L1';

--- a/Tests/test_plotting.m
+++ b/Tests/test_plotting.m
@@ -1,4 +1,3 @@
-clearvars; 
 % Test plotting 
 clearvars; clc;
 
@@ -6,6 +5,7 @@ addpath('..')
 addpath(genpath('../utilities/'))
 addpath(genpath('../datasets/'))
 addpath(genpath('../m_map/'))
+
 bbox = [166 176;		% lon_min lon_max
         -48 -40]; 		% lat_min lat_max
 min_el    = 1e3;  		% minimum resolution in meters.

--- a/Tests/test_plotting.m
+++ b/Tests/test_plotting.m
@@ -29,6 +29,9 @@ bbox_s =  [172   176;
        
 close all; 
 %%
+m.b = rand(length(m.p(:,1)),1); 
+m.bx = rand(length(m.p(:,1)),1); 
+m.by = rand(length(m.p(:,1)),1); 
 
 % start testing all types
 types = {'tri','bd','ob','b','slp','reso','resodx','qual'}; 

--- a/Tests/test_plotting.m
+++ b/Tests/test_plotting.m
@@ -1,0 +1,44 @@
+clearvars; 
+% Test plotting 
+clearvars; clc;
+
+addpath('..')
+addpath(genpath('../utilities/'))
+addpath(genpath('../datasets/'))
+addpath(genpath('../m_map/'))
+bbox = [166 176;		% lon_min lon_max
+        -48 -40]; 		% lat_min lat_max
+min_el    = 1e3;  		% minimum resolution in meters.
+max_el    = 100e3; 		% maximum resolution in meters. 
+max_el_ns = 5e3;        % maximum resolution nearshore in meters.
+grade     = 0.35; 		% mesh grade in decimal percent.
+R         = 3;    		% number of elements to resolve feature width.
+coastline = 'GSHHS_f_L1';
+gdat = geodata('shp',coastline,'bbox',bbox,'h0',min_el);
+fh = edgefx('geodata',gdat,...
+            'fs',R,'max_el_ns',max_el_ns,...
+            'max_el',max_el,'g',grade);
+mshopts = meshgen('ef',fh,'bou',gdat,'plot_on',1,'nscreen',5,'proj','trans');
+mshopts = mshopts.build; 
+m = mshopts.grd;
+m = make_bc(m,'auto',gdat,'distance'); % make the boundary conditions
+
+
+bbox_s =  [172   176;
+           -42   -39];
+       
+close all; 
+%%
+
+% start testing all types
+types = {'tri','bd','ob','b','slp','reso','resodx','qual'}; 
+add   = {'notri','earth','log','mesh'}; 
+projs = {}; 
+for i = 1 : length(types)
+    for j = 1 : length(add)
+        test = strcat(types{i},add{j}); 
+        disp(['Testing plotting option: ',test]); 
+        plot(m,'type',types{i});
+        pause; disp('Look right?'); close all; 
+    end
+end

--- a/utilities/setProj.m
+++ b/utilities/setProj.m
@@ -1,4 +1,4 @@
-function [del,obj] = setProj(obj,proj,projtype,insert)
+function [del,obj] = setProj(obj,proj,projtype,insert,bbox)
     % [del,obj] = setProj(obj,proj,projtype,insert)
     % kjr generic function to parse projected space options
     % returns del flag to delete overlapping elements when plotting
@@ -10,10 +10,20 @@ function [del,obj] = setProj(obj,proj,projtype,insert)
         insert = 0;
     end
     
-    % process bounds of mesh
-    lon_mi = min(obj.p(:,1)); lon_ma = max(obj.p(:,1));
-    lat_mi = min(obj.p(:,2)); lat_ma = max(obj.p(:,2));
+    if nargin < 5
+        bbox = [];
+    end
+    
+    % process bounds of mesh (or supply your own)
+    if isempty(bbox)
+        lon_mi = min(obj.p(:,1)); lon_ma = max(obj.p(:,1));
+        lat_mi = min(obj.p(:,2)); lat_ma = max(obj.p(:,2));
+    else
+        lon_mi = bbox(1,1); lon_ma = bbox(1,2);
+        lat_mi = bbox(2,1); lat_ma = bbox(2,2);
+    end
     lat_mea = mean(obj.p(:,2)); lon_mea = mean(obj.p(:,1));
+    
     % some defaults
     rad = 100; rot = 15;
     del = 0 ;


### PR DESCRIPTION
* User can set the axis limits with a kwarg `axis_limits` which over rides the default mesh extents.
```
plot(m,'type','tri','proj','lamb','axis_limits',[164, 178; -48 -40]);
```