### PR TITLE
incremental Mannings N calculation

### DIFF
--- a/utilities/Calc_Mannings_Landcover.m
+++ b/utilities/Calc_Mannings_Landcover.m
@@ -15,8 +15,9 @@ function obj = Calc_Mannings_Landcover(obj,data,type,varargin)
 % varargin: Accepts the same options as for msh.interp to control how 
 %           data is interpolated; see 'help msh.interp'
 % 
-%  Author:            WP July 19, 2018
+%  Author:            KR & WP July 19, 2018
 %  Update for CCAP:   WP May 5, 2021
+%  Update for storing incremental interpolation results: KJ & OK July 9, 2021
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 if nargin < 3 || isempty(type)
@@ -85,9 +86,15 @@ numnodes = length(find(Man ~= default_val));
 obj.f13.userval.Atr(NA).usernumnodes = numnodes ;
 % Print out list of nodes for each
 K = find(Man ~= default_val);
-obj.f13.userval.Atr(NA).Val = [K ; Man(K)];
+if isfield(obj.f13.userval.Atr(NA),'Val')
+    [idx,~] = ismember(obj.f13.userval.Atr(NA).Val(1,:),K);
+    for ww = 1: length(find(idx==1))
+        obj.f13.userval.Atr(NA).Val(2,idx(ww)) = Man(K(ww));
+    end
+else
+    obj.f13.userval.Atr(NA).Val = [K ; Man(K)];
+end
 %EOF
 end
-
 
 

--- a/utilities/Calc_Mannings_Landcover.m
+++ b/utilities/Calc_Mannings_Landcover.m
@@ -87,10 +87,7 @@ obj.f13.userval.Atr(NA).usernumnodes = numnodes ;
 % Print out list of nodes for each
 K = find(Man ~= default_val);
 if isfield(obj.f13.userval.Atr(NA),'Val')
-    [idx,~] = ismember(obj.f13.userval.Atr(NA).Val(1,:),K);
-    for ww = 1: length(find(idx==1))
-        obj.f13.userval.Atr(NA).Val(2,idx(ww)) = Man(K(ww));
-    end
+    obj.f13.userval.Atr(NA).Val = [obj.f13.userval.Atr(NA).Val'; K' , Man(K)']';
 else
     obj.f13.userval.Atr(NA).Val = [K ; Man(K)];
 end


### PR DESCRIPTION
* Often the landcover databases are large and require the calculation to be broken up into slices using for example the `K` index option.
* This commit won't over write the existing values for the Manning n data that were already calculated. Instead it appends it saving the existing values.