### PR TITLE
m_trimesh patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - 'invert' option in the msh.interp method to turn off the DEM value inversion typically performed
 
 ## Changed
+- forcing facecolor to white in `m_trimesh` so that it does not intefere with background color option
 - for the make_bc msh method 'auto'/'auto_outer' options, allowing for the 'depth' method of classification to use the interpolated depths on the mesh if gdat is empty.
 - improving help for make_bc msh method, Make_f15.m and Calc_Sponge.m
 - renamed "ExtractSubDomain.m" to "extract_subdomain.m"

--- a/utilities/m_trimesh.m
+++ b/utilities/m_trimesh.m
@@ -13,9 +13,6 @@ end
 
 [X,Y]=m_ll2xy(long,lat,'clip','on');  
 
-hold on; trimesh(tri,X,Y,z,'facecolor', 'none'); 
-%trimesh(tri,X,Y,z,'facecolor', 'flat', 'edgecolor', 'none'); 
-
-%m_coast('patch','red') ; 
+hold on; trimesh(tri,X,Y,z,'facecolor', 'w'); 
 
 end


### PR DESCRIPTION
forces facecolor to white in `m_trimesh` so the background color does not appear behind the triangles (only in the region outside of the triangulation) 