### PR TITLE
correcting outgw in readfort15 to outgm

### DIFF
--- a/@msh/private/readfort15.m
+++ b/@msh/private/readfort15.m
@@ -314,7 +314,7 @@ end
 
 % NOUTGW
 if ( f15dat.nws ~= 0 ) 
-    f15dat.outgw = readlinevec( fid ) ;
+    f15dat.outgm = readlinevec( fid ) ;
 end
 
 


### PR DESCRIPTION
- `outgm` is used in `writefort15.m` and `Make_f15.m` functions.

See #249 