### PR TITLE
Default msh.clean options

### DIFF
--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -1063,7 +1063,7 @@ classdef msh
             else
                 disp('Employing default (medium) option or user-specified opts')
                 opt.db = 0.25; opt.ds = 2; opt.con = 9; opt.djc = 0.1;
-                opt.sc_maxit = 1; opt.mqa = 0.25; opt.renum = 1;
+                opt.sc_maxit = 0; opt.mqa = 0.25; opt.renum = 1;
                 varargin(strcmp(varargin,'default')) = [];
                 varargin(strcmp(varargin,'medium')) = [];
             end

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -3946,8 +3946,13 @@ classdef msh
                     % Remove open boundary info...
                     obj.op = [];
                 else
-                    % Remove unnessary part from the nbdv
+                    % Remove zero length boundary and unnessary part from the nbdv
                     obj.op.nbdv = obj.op.nbdv(1:max(obj.op.nvdll),:);
+                    zero_bound = obj.op.nvdll == 0;
+                    obj.op.nope = sum(~zero_bound);
+                    obj.op.ibtype(zero_bound) = [];
+                    obj.op.nvdll(zero_bound) = [];
+                    obj.op.nbdv(:,zero_bound) = [];
                 end
             end
             % land boundary info

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -1057,12 +1057,12 @@ classdef msh
                 varargin(strcmp(varargin,'passive')) = [];
             elseif any(strcmp(varargin,'aggressive'))
                 disp('Employing aggressive option')
-                opt.db = 0.5; opt.ds = 1; opt.con = 9; opt.djc = 0.25;
+                opt.db = 0.5; opt.ds = 2; opt.con = 9; opt.djc = 0.25;
                 opt.sc_maxit = inf; opt.mqa = 0.5; opt.renum = 1;
                 varargin(strcmp(varargin,'aggressive')) = [];
             else
                 disp('Employing default (medium) option or user-specified opts')
-                opt.db = 0.25; opt.ds = 1; opt.con = 9; opt.djc = 0.1;
+                opt.db = 0.25; opt.ds = 2; opt.con = 9; opt.djc = 0.1;
                 opt.sc_maxit = 1; opt.mqa = 0.25; opt.renum = 1;
                 varargin(strcmp(varargin,'default')) = [];
                 varargin(strcmp(varargin,'medium')) = [];

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Unreleased (on current HEAD of the Projection branch)
 ## Added
 - Geoid offset nodal attribute in `Calc_f13` subroutine. https://github.com/CHLNDDEV/OceanMesh2D/pull/251
+## Changed
+- Default mesh imrpovement strategy is `ds` 2.
 
 ### [5.0.0] - 2021-07-29
 ## Added

--- a/Tests/TestSanity.m
+++ b/Tests/TestSanity.m
@@ -4,7 +4,7 @@ run('../Examples/Example_1_NZ.m')
 
 NP_TOL = 500;
 NT_TOL = 1500;
-QUAL_TOL = 0.5;
+QUAL_TOL = 0.25; %[mqa for medium cleaning option]
 % p: [5968×2 double]
 % t: [9530×3 double]
 % Element qual. metrics


### PR DESCRIPTION
* Make default smoothing option for `msh.clean` medium and aggressive models the hill-climbing approach.