### PR TITLE
Enhancements/msh class

### DIFF
--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -3854,10 +3854,11 @@ classdef msh
             egfix = renumberEdges(egfix) ;
         end
 
-        function boundary = get_boundary_of_mesh(obj,ascell)
-            % boundary = get_boundary_of_mesh(obj,ascell)
+        function [boundary, bou_index] = get_boundary_of_mesh(obj,ascell)
+            % [boundary, bou_index] = get_boundary_of_mesh(obj,ascell)
             %
-            % Returns the boundary of the mesh
+            % Returns the boundary of the mesh and/or the mesh indices of
+            % the boundary
             %
             % INPUTS: msh_obj
             % OUTPUTS: msh boundary in one of two forms:
@@ -3872,13 +3873,14 @@ classdef msh
             end
             bnde = extdom_edges2(obj.t,obj.p) ;
             try
-                boundary = extdom_polygon(bnde,obj.p,-1) ;
+                [boundary,bou_index] = extdom_polygon(bnde,obj.p,-1) ;
             catch
                 warning('ALERT: Boundary of mesh is not walkable. Returning polylines.');
-                boundary = extdom_polygon(bnde,obj.p,-1,1) ;
+                [boundary,bou_index] = extdom_polygon(bnde,obj.p,-1,1) ;
             end
             if ascell; return; end
             boundary = cell2mat(boundary');
+            bou_index = cell2mat(bou_index');
         end
 
         function obj = map_mesh_properties(obj,varargin)

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -59,6 +59,7 @@ classdef msh
         f24 % A struct of the fort24 SAL values
         f2001 % A struct for the fort2001 non-periodic flux/ele sponge bc
         f5354 % A struct for the fort53001/54001 tidal ele/flux sponge bc
+        offset63 % A struct for the offset.63 dynamicwaterlevelcorrection file
         proj   % Description of projected space (m_mapv1.4)
         coord  % Description of projected space (m_mapv1.4)
         mapvar % Description of projected space (m_mapv1.4)
@@ -216,6 +217,9 @@ classdef msh
                 if ~isempty(obj.f5354)
                     writefort5354( obj.f5354, fname );
                 end
+                if ~isempty(obj.offset63)
+                    writeoffset63( obj.offset63, [fname '.offset.63'] );
+                end
             else
                 if any(contains(type,'14')) || any(contains(type,'ww3')) || ...
                         any(contains(type,'gr3'))
@@ -268,6 +272,9 @@ classdef msh
                 end
                 if any(contains(type,'5354')) && ~isempty(obj.f5354)
                     writefort5354( obj.f5354, fname );
+                end
+                if any(contains(type,'offset')) && ~isempty(obj.offset63)
+                    writeoffset63( obj.offset63, [fname '.offset.63'] );
                 end
             end
         end

--- a/@msh/private/writeoffset63.m
+++ b/@msh/private/writeoffset63.m
@@ -1,0 +1,22 @@
+function fid = writeoffset63( f63dat, finame )
+%
+%
+if ( nargin == 1 ) 
+	finputname = 'offset.63' ;
+else
+	finputname = finame ;   
+end
+
+fid = fopen(finputname,'w') ;
+fprintf(fid,'%s \n',f63dat.header) ; 
+fprintf(fid,'%12.6f \n',f63dat.time_interval) ;
+fprintf(fid,'%12.6f \n',f63dat.default_val) ;
+
+for tt = 1: f63dat.num_times
+    fprintf(fid,'%d \t %12.6f \n',[f63dat.offset_nodes; f63dat.offset_values(tt,:)]);
+    fprintf(fid,'%s \n','##'); 
+end
+  
+fclose(fid) ; 
+%EOF
+end

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Retrieve boundary indices in `msh.get_boundary_of_mesh` method. https://github.com/CHLNDDEV/OceanMesh2D/pull/259
 - `msh.offset63` struct and associated write/make routines for dynamicwaterlevel offset functionality. https://github.com/CHLNDDEV/OceanMesh2D/pull/259
 ## Fixed
-- `msh.interp` method for `K` argument of length 1, and for the test to do determine in bathymetry grid is irregular. https://github.com/CHLNDDEV/OceanMesh2D/pull/259
+- `msh.interp` method for `K` argument of length 1, and for the test to determine whether the bathymetry grid is irregular. https://github.com/CHLNDDEV/OceanMesh2D/pull/259
 
 ### [5.0.0] - 2021-07-29
 ## Added

--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Unreleased (on current HEAD of the Projection branch)
 ## Added
 - Geoid offset nodal attribute in `Calc_f13` subroutine. https://github.com/CHLNDDEV/OceanMesh2D/pull/251
+- Retrieve boundary indices in `msh.get_boundary_of_mesh` method. https://github.com/CHLNDDEV/OceanMesh2D/pull/259
+- `msh.offset63` struct and associated write/make routines for dynamicwaterlevel offset functionality. https://github.com/CHLNDDEV/OceanMesh2D/pull/259
+## Fixed
+- `msh.interp` method for `K` argument of length 1, and for the test to do determine in bathymetry grid is irregular. https://github.com/CHLNDDEV/OceanMesh2D/pull/259
 
 ### [5.0.0] - 2021-07-29
 ## Added

--- a/utilities/FindLinearIdx.m
+++ b/utilities/FindLinearIdx.m
@@ -17,8 +17,8 @@ y = y(:);
 % (trying both directions so could be meshgrid or ndgrid format)
 dx  = diff(lon(:,1));
 dy  = diff(lat(1,:));
-
-if max(dx) ~= min(dx) || max(dy) ~= min(dy)
+dx_cutoff = 0.1/111e3; % approx 10 cm 
+if (max(dx) - min(dx)) > dx_cutoff || (max(dy) - min(dy)) > dx_cutoff
     % % IRREGULAR GRID (SLOWER)
     
     % convert ndgrid to vector

--- a/utilities/FindLinearIdx.m
+++ b/utilities/FindLinearIdx.m
@@ -9,7 +9,7 @@ ny = size(lon,1);
 nx = size(lon,2);
 np = numel(x);
 
-if ny == 1 && ny == 1
+if nx == 1 && ny == 1
    IX = 1; IX1 = 1; IX2 = 1;
    return
 end

--- a/utilities/FindLinearIdx.m
+++ b/utilities/FindLinearIdx.m
@@ -9,6 +9,11 @@ ny = size(lon,1);
 nx = size(lon,2);
 np = numel(x);
 
+if ny == 1 && ny == 1
+   IX = 1; IX1 = 1; IX2 = 1;
+   return
+end
+
 % make sure entry points are column vectors
 x = x(:);
 y = y(:);

--- a/utilities/Make_offset63.m
+++ b/utilities/Make_offset63.m
@@ -1,0 +1,41 @@
+function obj = Make_offset63(obj,time_vector,offset_nodes,offset_values)
+% obj = Make_offset63(obj,time_vector,offset_nodes,offset_values)
+% 
+% Inputs:   obj            - msh class 
+%           time_vector    - datetime vector : size NTx1 or 1xNT
+%           offset_nodes   - offset nodes    : size 1xNP
+%           offset_values  - offset values   : size NTxNP
+%
+%  Author:      William Pringle                                 
+%  Created:     Nov 22 2021                                      
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+if size(offset_nodes,1) ~= 1
+   if size(offset_nodes,2) == 1 
+       offset_nodes = offset_nodes';
+   else
+       error('offset_nodes size must be 1xNP')
+   end
+end
+if size(offset_values,1) ~= length(time_vector)
+   error('offset_values size of 1st dimension must be same as time_vector length')
+end
+if size(offset_values,2) ~= length(offset_nodes)
+   error('offset_values size of 2nd dimension must be same as offset_nodes length')
+end
+        
+% enter in msh.offset63 struct
+obj.offset63.header = ['#dynamicwaterleveloffsets from ' ...
+                datestr(time_vector(1)) ' to  ' datestr(time_vector(end))];
+obj.offset63.num_times = length(time_vector);
+obj.offset63.time_interval = round(...
+                              seconds(time_vector(end) - time_vector(1))/ ...
+                              length(time_vector)...
+                             );
+obj.offset63.default_val = 0;
+obj.offset63.offset_nodes = offset_nodes;
+obj.offset63.offset_values = offset_values;
+%EOF
+end
+
+


### PR DESCRIPTION
- add ability to retrieve mesh boundary indices
- add offset63 struct to `msh` class for the [dynamicwaterlevelcorrection](https://wiki.adcirc.org/wiki/Dynamic_water_level_correction) functionality
- correcting interpolation of bathymetry for `msh.interp` when K argument has a length of 1, and in the test for irregular structured grid