### PR TITLE
meshgen optionality

### DIFF
--- a/@meshgen/meshgen.m
+++ b/@meshgen/meshgen.m
@@ -39,7 +39,10 @@ classdef meshgen
     %         qual_tol      % tolerance for the accepted negligible change in quality
     %         enforceWeirs  % whether or not to enforce weirs in meshgen
     %         enforceMin    % whether or not to enfore minimum edgelength for all edgefxs
+    % delaunay_elim_on_exit % whether or not to run delaunay_elim on exit of meshgen   
+    % improve_with_reduced_quality % whether or not to allow mesh improvements with decreases in mesh quality
     %         big_mesh      % set to 1 to remove the bou data from memory
+    %       
     properties
         fd            % handle to distance function
         fh            % handle to edge function
@@ -73,6 +76,8 @@ classdef meshgen
         Fb            % bathymetry data interpolant
         enforceWeirs  % whether or not to enforce weirs in meshgen
         enforceMin    % whether or not to enfore minimum edgelength for all edgefxs
+        delaunay_elim_on_exit % whether or not to run delaunay_elim on exit of meshgen   
+        improve_with_reduced_quality % whether or not to allow mesh improvements with decreases in mesh quality
     end
 
 
@@ -126,6 +131,8 @@ classdef meshgen
             addOptional(p,'qual_tol',defval);
             addOptional(p,'enforceWeirs',1);
             addOptional(p,'enforceMin',1);
+            addOptional(p,'delaunay_elim_on_exit',1);
+            addOptional(p,'improve_with_reduced_quality',0);
 
             % parse the inputs
             parse(p,varargin{:});
@@ -137,7 +144,9 @@ classdef meshgen
             % kjr...order these argument so they are processed in a predictable
             % manner. Process the general opts first, then the OceanMesh
             % classes...then basic non-critical options.
-            inp = orderfields(inp,{'h0','bbox','enforceWeirs','enforceMin','fh',...
+            inp = orderfields(inp,{'h0','bbox','enforceWeirs','enforceMin',...
+                                   'delaunay_elim_on_exit','improve_with_reduced_quality',...
+                                   'fh',...
                                    'inner','outer','mainland',...
                                    'bou','ef',... %<--OceanMesh classes come after
                                    'egfix','pfix','fixboxes',...
@@ -409,6 +418,10 @@ classdef meshgen
                         obj.enforceWeirs = inp.(fields{i});
                     case('enforceMin')
                         obj.enforceMin = inp.(fields{i});
+                    case('delaunay_elim_on_exit')
+                        obj.delaunay_elim_on_exit = inp.(fields{i});
+                    case('improve_with_reduced_quality')
+                        obj.improve_with_reduced_quality = inp.(fields{i});
                 end
             end
 
@@ -660,9 +673,13 @@ classdef meshgen
                     
                     
                     % If mesh quality went down "significantly" since last iteration
-                    % which was a mesh improvement iteration, then rewind.
-                    if ~mod(it,imp+1) && obj.qual(it,1) - obj.qual(it-1,1) < -0.10 || ...
-                            ~mod(it,imp+1) && (N - length(p_before_improve))/length(p_before_improve) < -0.10
+                    % ..or.. 
+                    % If not allowing improvements with reduction in quality 
+                    % then if the number of points significantly decreased
+                    % due to a mesh improvement iteration, then rewind.
+                    if ~mod(it,imp+1) && ((obj.qual(it,1) - obj.qual(it-1,1) < -0.10)  || ...
+                        (~improve_with_reduced_quality && ...
+                        (N - length(p_before_improve))/length(p_before_improve) < -0.10))
                         disp('Mesh improvement was unsuccessful...rewinding...');
                         p = p_before_improve; 
                         N = size(p,1);                                     % Number of points changed
@@ -734,7 +751,9 @@ classdef meshgen
                 if ~mod(it,imp)
                     if abs(qual_diff) < obj.qual_tol
                         % Do the final elimination of small connectivity
-                        [t,p] = delaunay_elim(p,obj.fd,geps,1);
+                        if delaunay_elim_on_exit
+                            [t,p] = delaunay_elim(p,obj.fd,geps,1);
+                        end
                         disp('Quality of mesh is good enough, exit')
                         close all;
                         break;
@@ -796,7 +815,7 @@ classdef meshgen
                 if ~mod(it,imp)
                     p_before_improve = p;
                     nn = []; pst = [];
-                    if qual_diff < imp*obj.qual_tol && qual_diff > 0
+                    if abs(qual_diff) < imp*obj.qual_tol && (improve_with_reduced_quality || qual_diff > 0)
                         % Remove elements with small connectivity
                         nn = get_small_connectivity(p,t);
                         disp(['Deleting ' num2str(length(nn)) ' due to small connectivity'])
@@ -870,7 +889,9 @@ classdef meshgen
 
                 if ( it > obj.itmax )
                     % Do the final deletion of small connectivity
-                    [t,p] = delaunay_elim(p,obj.fd,geps,1);
+                    if delaunay_elim_on_exit
+                        [t,p] = delaunay_elim(p,obj.fd,geps,1);
+                    end
                     disp('too many iterations, exit')
                     close all;
                     break ;

--- a/@meshgen/meshgen.m
+++ b/@meshgen/meshgen.m
@@ -678,7 +678,7 @@ classdef meshgen
                     % then if the number of points significantly decreased
                     % due to a mesh improvement iteration, then rewind.
                     if ~mod(it,imp+1) && ((obj.qual(it,1) - obj.qual(it-1,1) < -0.10)  || ...
-                        (~improve_with_reduced_quality && ...
+                        (~obj.improve_with_reduced_quality && ...
                         (N - length(p_before_improve))/length(p_before_improve) < -0.10))
                         disp('Mesh improvement was unsuccessful...rewinding...');
                         p = p_before_improve; 
@@ -751,7 +751,7 @@ classdef meshgen
                 if ~mod(it,imp)
                     if abs(qual_diff) < obj.qual_tol
                         % Do the final elimination of small connectivity
-                        if delaunay_elim_on_exit
+                        if obj.delaunay_elim_on_exit
                             [t,p] = delaunay_elim(p,obj.fd,geps,1);
                         end
                         disp('Quality of mesh is good enough, exit')
@@ -815,7 +815,8 @@ classdef meshgen
                 if ~mod(it,imp)
                     p_before_improve = p;
                     nn = []; pst = [];
-                    if abs(qual_diff) < imp*obj.qual_tol && (improve_with_reduced_quality || qual_diff > 0)
+                    if abs(qual_diff) < imp*obj.qual_tol && ...
+                        (obj.improve_with_reduced_quality || qual_diff > 0)
                         % Remove elements with small connectivity
                         nn = get_small_connectivity(p,t);
                         disp(['Deleting ' num2str(length(nn)) ' due to small connectivity'])
@@ -889,7 +890,7 @@ classdef meshgen
 
                 if ( it > obj.itmax )
                     % Do the final deletion of small connectivity
-                    if delaunay_elim_on_exit
+                    if obj.delaunay_elim_on_exit
                         [t,p] = delaunay_elim(p,obj.fd,geps,1);
                     end
                     disp('too many iterations, exit')

--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -1197,17 +1197,21 @@ classdef msh
             qual = [mq_m,mq_l3sig,mq_l];
             LTn = size(obj.t,1);
 
-            if mq_l < opt.mqa && (opt.ds || LT ~= LTn)
+            if mq_l < opt.mqa && LT ~= LTn
                 % Need to clean it again
                 disp('Poor or overlapping elements, cleaning again')
                 disp(['(Min Qual = ' num2str(mq_l) ')'])
                 % repeat without projecting (already projected)
-                ii = find(strcmp(varargino,'proj'));
+                ii = find(strcmp(varargino,'proj'), 1);
                 if ~isempty(ii)
                     varargino{ii+1} = 0;
                 else
                     varargino{end+1} = 'proj';
                     varargino{end+1} = 0;
+                end
+                ii = find(strcmp(varargino,'pfix'), 1);
+                if ~isempty(ii)
+                    varargino{ii+1} = pfixV;
                 end
                 obj = clean(obj,varargino(:));
             elseif opt.nscreen

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Unreleased (on current HEAD of the Projection branch)
 ## Added
+- Option `improve_with_reduced_quality` to `meshgen` for allowing for mesh improvements even when quality is decreasing or large number of nodes eliminated, which sometimes is necessary to force the advancement in mesh quality.
+- Option `delaunay_elim_on_exit` to `meshgen` to skip the last call to `delaunay_elim` to potentially avoid deleting boundary elements.
 - Geoid offset nodal attribute in `Calc_f13` subroutine. https://github.com/CHLNDDEV/OceanMesh2D/pull/251
 - Support for writing Self Attraction and Loading (SAL) files in NetCDF for the ADCIRC model. https://github.com/CHLNDDEV/OceanMesh2D/pull/231
 ## Changed
@@ -157,6 +159,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `msh.offset63` struct and associated write/make routines for dynamicwaterlevel offset functionality. https://github.com/CHLNDDEV/OceanMesh2D/pull/259
 - dynamicWaterLevelCorrection to fort.15 namelist, and PRBCKGRND option to met fort.15 namelist. https://github.com/CHLNDDEV/OceanMesh2D/pull/261
 ## Fixed
+- Recursive cleaning issues: infinite loop and preservation of fixed points.
 - `msh.interp` method for `K` argument of length 1, and for the test to determine whether the bathymetry grid is irregular. https://github.com/CHLNDDEV/OceanMesh2D/pull/259
 - Printing of namelist character strings or numbers. https://github.com/CHLNDDEV/OceanMesh2D/pull/261
 - `Make_offset63.m` time interval computation. https://github.com/CHLNDDEV/OceanMesh2D/pull/261


### PR DESCRIPTION
1. adding option `improve_with_reduced_quality` to `meshgen` for allowing for mesh improvements even when quality is decreasing or large number of nodes eliminated, which sometimes is necessary to force the advancement in mesh quality. 
2. adding option `delaunay_elim_on_exit` to `meshgen`  to potentially skip the last call to delaunay_elim to potentially avoid deleting boundary elements.
3. fixing recursive cleaning issues.