### PR TITLE
Bug fix: station name reading methods

### DIFF
--- a/@msh/private/readfort15.m
+++ b/@msh/private/readfort15.m
@@ -256,12 +256,13 @@ f15dat.nstae = readlinescalar( fid ) ;
  
 % STAE location
 if ( f15dat.nstae > 0 )
-    
     f15dat.elvstaloc = zeros(f15dat.nstae,2) ;
+    f15dat.elvstaname = strings(f15dat.nstae,1)  ; 
     for k = 1: f15dat.nstae
-        val = readlinevec( fid ) ;
-        
+        [val,name] = readlinevecname( fid ) ; 
+
         f15dat.elvstaloc(k,1:2) = val(1:2)' ;
+        f15dat.elvstaname(k) = name; 
     end
 end
 
@@ -274,11 +275,13 @@ f15dat.velstaloc = [] ;
 
 % STAV location
 if ( f15dat.nstav > 0 ) 
-    f15dat.velstaloc = zeros(f15dat.nstav,2) ;
+    f15dat.velstaloc = zeros(f15dat.nstav,2) ; 
+    f15dat.velstaname = strings(f15dat.nstav,1)  ; 
     for k = 1: f15dat.nstav
-        val = readlinevec( fid ) ; 
-        
+        [val,name] = readlinevecname( fid ) ; 
+
         f15dat.velstaloc(k,1:2) = val ; 
+        f15dat.velstaname(k) = name ; 
     end
 end
 
@@ -316,7 +319,6 @@ end
 if ( f15dat.nws ~= 0 ) 
     f15dat.outgm = readlinevec( fid ) ;
 end
-
 
 % NFREQ 
 f15dat.nfreq = readlinescalar( fid ) ; 
@@ -379,5 +381,12 @@ fclose(fid) ;
        [token,rem] = strtok(msg) ; 
         
     end
- 
+
+    function [vec, name] = readlinevecname( fid )
+        
+        msg = fgetl(fid) ; 
+        [token, name] = strtok(msg,"!");
+        vec = sscanf(token,'%f');
+    
+    end 
 end

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Printing of namelist character strings or numbers. https://github.com/CHLNDDEV/OceanMesh2D/pull/261
 - `Make_offset63.m` time interval computation. https://github.com/CHLNDDEV/OceanMesh2D/pull/261 and https://github.com/CHLNDDEV/OceanMesh2D/pull/272
 - Removed dependency on statistics toolbox when using the 'nanfill' option in `msh.interp`. https://github.com/CHLNDDEV/OceanMesh2D/pull/269
+- Missing routines for reading in elvstaname and velstaname in readfort15.m by adding readlinevecname() method. https://github.com/CHLNDDEV/OceanMesh2D/pull/281 
 
 ### [5.0.0] - 2021-07-29
 ## Added


### PR DESCRIPTION
Encountered write-out bug when trying to read in fort.15, add tides, then write out fort.15 because of missing read methods for elvstaname and velstaname. Modified STAV and STAE code by adding readlinevecname() method which returns first two tokens as a float array and last token as string, assuming station name is delimited by "!" symbol. 