### PR TITLE
Various bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `msh.offset63` struct and associated write/make routines for dynamicwaterlevel offset functionality. https://github.com/CHLNDDEV/OceanMesh2D/pull/259
 - dynamicWaterLevelCorrection to fort.15 namelist, and PRBCKGRND option to met fort.15 namelist. https://github.com/CHLNDDEV/OceanMesh2D/pull/261
 ## Fixed
+- Updated `Calc_f13.m` to avoid an "Unrecognized variable" error by ensuring "broken" is always defined. https://github.com/CHLNDDEV/OceanMesh2D/pull/282
+- Fixed test for likely geographic coordinates in `Make_f15.m`. https://github.com/CHLNDDEV/OceanMesh2D/pull/282
 - updated `Gridded_to_Mesh_SeaBed_DepthAveraged.m` to fix the infinite loop in using `Cal_IT_Fric.m` by filling in the NaNs at greater depths with values from above. https://github.com/CHLNDDEV/OceanMesh2D/pull/280
 - Recursive cleaning issues: infinite loop and preservation of fixed points.
 - `msh.interp` method for `K` argument of length 1, and for the test to determine whether the bathymetry grid is irregular. https://github.com/CHLNDDEV/OceanMesh2D/pull/259

--- a/utilities/Calc_f13.m
+++ b/utilities/Calc_f13.m
@@ -89,6 +89,7 @@ if isempty(obj.f13)
     obj.f13.NumOfNodes = length(obj.p);
     obj.f13.nAttr = 1;
     NA = 1;
+    broken = 0;
 else
     broken = 0;
     for NA = 1:obj.f13.nAttr

--- a/utilities/Make_f15.m
+++ b/utilities/Make_f15.m
@@ -65,7 +65,7 @@ if isempty(obj.f15)
     % IHOT (cold start)
     f15dat.ihot = 0;
     % ICS 
-    if all(abs(obj.p(:,1))) <= 180 && all(abs(obj.p(:,2))) <= 90
+    if all(abs(obj.p(:,1)) <= 180) && all(abs(obj.p(:,2)) <= 90)
         f15dat.ics = 2 ; % uses lat, lon (probably)
     else
         f15dat.ics = 1 ; % not lat, lon


### PR DESCRIPTION
In [Calc_f13.m](https://github.com/CHLNDDEV/OceanMesh2D/blob/Projection/utilities/Calc_f13.m): If "obj.f13" is empty, then "broken" is undefined and the code breaks when default values are set on Line 109. Here we let broken=0 to allow default values to be defined.

In [Make_f15.m](https://github.com/CHLNDDEV/OceanMesh2D/blob/Projection/utilities/Make_f15.m): In original code, "all()" is acting on "abs(...)" and not the logical comparison. Here the parentheses are moved so that "all()" acts on the logical comparison in each coordinate.