### PR TITLE
Fixed ibtypee typo bug in map_mesh_properties

### DIFF
--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -3973,7 +3973,7 @@ classdef msh
                     obj.op.nbdv = obj.op.nbdv(1:max(obj.op.nvdll),:);
                     zero_bound = obj.op.nvdll == 0;
                     obj.op.nope = sum(~zero_bound);
-                    obj.op.ibtype(zero_bound) = [];
+                    obj.op.ibtypee(zero_bound) = [];
                     obj.op.nvdll(zero_bound) = [];
                     obj.op.nbdv(:,zero_bound) = [];
                 end

--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Printing of namelist character strings or numbers. https://github.com/CHLNDDEV/OceanMesh2D/pull/261
 - `Make_offset63.m` time interval computation. https://github.com/CHLNDDEV/OceanMesh2D/pull/261 and https://github.com/CHLNDDEV/OceanMesh2D/pull/272
 - Removed dependency on statistics toolbox when using the 'nanfill' option in `msh.interp`. https://github.com/CHLNDDEV/OceanMesh2D/pull/269
-- Missing routines for reading in elvstaname and velstaname in readfort15.m by adding readlinevecname() method. https://github.com/CHLNDDEV/OceanMesh2D/pull/281 
+- Missing routines for reading in elvstaname and velstaname in readfort15.m by adding readlinevecname() method. https://github.com/CHLNDDEV/OceanMesh2D/pull/281
+- Incorrect reference to `ibtype` was changed to `ibtypee` in `map_mesh_properties` function. https://github.com/CHLNDDEV/OceanMesh2D/pull/298
 
 ### [5.0.0] - 2021-07-29
 ## Added


### PR DESCRIPTION
An incorrect reference to `ibtype` causes an error.  It's within code working on the open boundaries, so it appears it should be `ibtypee`. Changing it fixed the error, in my case.  Though I'm unsure what test cases to compare with, since this seems to be a segment of code that's not been touched before.  