### PR TITLE
IMPRV: added remesh_patch function

### DIFF
--- a/@msh/msh.m
+++ b/@msh/msh.m
@@ -329,9 +329,9 @@ classdef msh
             %    v) 'pivot'   : value in meters for which to assume is datum when
             %                    plotting topo-bathymetry (default 0.0 m)
             %   'axis_limits' : Force the axes limits to be bounded by what
-            %                   is passed in bbox.  
-            %   'cmap':         The name of the cmocean colormap 
-            %                    (each option has different default)     
+            %                   is passed in bbox.
+            %   'cmap':         The name of the cmocean colormap
+            %                    (each option has different default)
             %                    type 'help cmocean' to see all the colormaps
             %                    available
 
@@ -342,11 +342,11 @@ classdef msh
             pivot = 0.0; % assume datum is 0.0 m
             proj = 1;
             axis_limits = []; % use mesh extents to determine plot extents
-            cmap = 1; % default value is specified in plot method 
+            cmap = 1; % default value is specified in plot method
             leg_ind = [];
-            
-            projtype = []; 
-            type = 'tri'; 
+
+            projtype = [];
+            type = 'tri';
             subdomain = [];
             for kk = 1:2:length(varargin)
                 if strcmp(varargin{kk},'fontsize')
@@ -362,13 +362,13 @@ classdef msh
                 elseif strcmp(varargin{kk}, 'proj')
                     projtype = varargin{kk+1};
                 elseif strcmp(varargin{kk},'type')
-                    type = varargin{kk+1}; 
+                    type = varargin{kk+1};
                 elseif strcmp(varargin{kk},'subdomain')
-                    subdomain = varargin{kk+1}; 
+                    subdomain = varargin{kk+1};
                 elseif strcmp(varargin{kk},'axis_limits')
-                    axis_limits = varargin{kk+1}; 
+                    axis_limits = varargin{kk+1};
                 elseif strcmp(varargin{kk}, 'cmap')
-                    cmap = varargin{kk+1}; 
+                    cmap = varargin{kk+1};
                 end
             end
 
@@ -540,7 +540,7 @@ classdef msh
                        q = obj.b;
                     end
                     if cmap == 1
-                        cmap = '-topo';                        
+                        cmap = '-topo';
                     end
                     plotter(cmap,1,'depth below datum [m]',true);
                     title('mesh topo-bathy');
@@ -633,7 +633,7 @@ classdef msh
                         q = nq;
                     end
                     if cmap == 1
-                       cmap = 'matter'; 
+                       cmap = 'matter';
                     end
                     plotter(cmap,3,'area-length ratio',false);
                     title('Mesh quality metric');
@@ -649,8 +649,8 @@ classdef msh
                         fastscatter(obj.p(:,1),obj.p(:,2),defval(1)*ones(length(obj.p),1));
                         fastscatter(obj.p(userval(1,:),1),obj.p(userval(1,:),2),values');
                     end
-                    if cmap == 1 
-                       cmap = 'deep';  
+                    if cmap == 1
+                       cmap = 'deep';
                     end
                     colormap(cmocean(cmap));
                     colorbar;
@@ -701,25 +701,25 @@ classdef msh
                         q = obj.p(:,1)*0 + defval;
                         q(userval(1,:),:) = userval(2:end,:)';
                         % just take the inf norm
-                        q = max(q,[],2); 
+                        q = max(q,[],2);
                         if logaxis
-                            q = abs(q); 
+                            q = abs(q);
                             q(q == 0) = min(q(q > 0));
                             if length(cmap_int) >= 3
                                rd = ceil(-log10(cmap_int(2)));
                             else
-                               rd = ceil(-log10(min(q))); 
+                               rd = ceil(-log10(min(q)));
                             end
                             q = log10(q);
                         else
-                           if length(cmap_int) >= 3 
+                           if length(cmap_int) >= 3
                               rd = ceil(-log10((cmap_int(3)-cmap_int(2))/cmap_int(1)));
                            else
                               rd = ceil(-log10((max(q) - min(q))/cmap_int(1)));
-                           end                             
+                           end
                         end
                         if cmap == 1
-                            cmap = lansey(cmap_int(1)); 
+                            cmap = lansey(cmap_int(1));
                         end
                         plotter(cmap,rd+1,'',false);
                         ax = gca;
@@ -791,7 +791,7 @@ classdef msh
                if apply_pivot
                   cmocean(cmap,cmap_int(1),'pivot',pivot);
                else
-                  try 
+                  try
                      cmocean(cmap,cmap_int(1));
                   catch
                      colormap(cmap)
@@ -963,7 +963,7 @@ classdef msh
             %                             (underwater is positive depth)
             %   lut      - A look up table (lut). See nlcd and ccap in
             %              datasets/ for examples
-            
+
             % if give cell of geodata or dems then interpolate all
             if iscell(geodata) || isstring(geodata)
                 for i = 1:length(geodata)
@@ -1338,7 +1338,7 @@ classdef msh
             % ---------
             % 'delete' - deletes a user-clicked land/mainland boundary condition from a msh.
             % varargins:
-            % index of land/mainland boundary to delete 
+            % index of land/mainland boundary to delete
 
             if nargin < 2
                 error('Needs type: one of "auto", "outer", "inner", "delete", or "weirs"')
@@ -1454,10 +1454,10 @@ classdef msh
                             if ~isempty(land)
                                [~,ldst] = ourKNNsearch(land',eb_mid',1);
                             else
-                               % set distance to be larger than dist_lim  
+                               % set distance to be larger than dist_lim
                                % everywhere when no land exists
                                ldst = eb_mid(:,1)*0 + 2*dist_lim;
-                            end    
+                            end
                             eb_class = ldst > dist_lim;
                             if strcmp(classifier,'both')
                                 % ii) based on depth
@@ -1882,7 +1882,7 @@ classdef msh
                         dir,obj.op,obj.bd); %<--updates op and bd.
 
                 case('delete')
-                    
+
                     temp = obj.bd.nbvv;
                     bounodes=obj.bd.nbvv ;
                     idx=sum(bounodes~=0);
@@ -1895,12 +1895,12 @@ classdef msh
                         k = k + 1 ;
                         bounodes(idx2(i):idx2(i+1)-1,2) = k ;
                     end
-                    
+
                     if isempty(varargin)
                         % have the user select the nodestring '
                         plot(obj,'type','bd','proj','none') ;
-              
-                        
+
+
                         dcm_obj = datacursormode(gcf);
                         title('use data cursor to select nodestring to be deleted');
                         pause
@@ -1911,14 +1911,14 @@ classdef msh
                         pltid = temp(:,del) ; pltid(pltid==0)=[] ;
                         hold on; m_plot(obj.p(pltid,1),obj.p(pltid,2),'r-','linewi',2) ;
                     else
-                        del = varargin{1}; 
+                        del = varargin{1};
                     end
                     disp(['Deleting boundary with index ',num2str(del)]) ;
-                    
+
                     obj.bd.nbvv(:,del)=[];
                     if isfield(obj.bd,'ibconn')
                         obj.bd.ibconn(:,del)=[];
-                        obj.bd.barinht(:,del)=[]; 
+                        obj.bd.barinht(:,del)=[];
                         obj.bd.barincfsb(:,del)=[];
                         obj.bd.barincfsp(:,del)=[];
                     end
@@ -2312,7 +2312,7 @@ classdef msh
                     %% can be extracted and then obj1, obj2 concentated together
                     % extract the inner region of obj1 (inset) from obj2 (base)
                     % assuming that the inset fits perfectly in the base
-                    obj1o = obj1; 
+                    obj1o = obj1;
                     if extract
                         [p1(:,1),p1(:,2)] = m_ll2xy(p1(:,1),p1(:,2)) ;
                         [p2(:,1),p2(:,2)] = m_ll2xy(p2(:,1),p2(:,2)) ;
@@ -2513,7 +2513,7 @@ classdef msh
 
             if ~isempty(obj1.f13)
                 disp('Carrying over obj1 f13 data + any corresponding obj2 f13 data')
-                if ~isempty(obj2.f13) 
+                if ~isempty(obj2.f13)
                    ob2name = {obj2.f13.userval.Atr.AttrName};
                 else
                    ob2name = {};
@@ -2527,14 +2527,14 @@ classdef msh
                     idx1 = ourKNNsearch(merge.p',obj1.p(idx1,:)',1);
                     jj = find(contains(ob2name,attname));
                     if ~isempty(jj)
-                       disp(['Carrying over obj1 and obj2 ' attname]) 
+                       disp(['Carrying over obj1 and obj2 ' attname])
                        idx2 = obj2.f13.userval.Atr(jj).Val(1,:)';
                        val2 = obj2.f13.userval.Atr(jj).Val(2:end,:)';
                        idx2 = ourKNNsearch(merge.p',obj2.p(idx2,:)',1);
                        idx = [idx1; idx2];
                        val = [val1; val2];
                     else
-                       disp(['Carrying over obj1 ' attname]) 
+                       disp(['Carrying over obj1 ' attname])
                        idx = idx1; val = val1;
                     end
                     [idx,I] = sort(idx,'ascend');
@@ -2858,7 +2858,7 @@ classdef msh
 
             % Conduct initial check of Courant number to return early if possible
             Cr = real(CalcCFL(obj,dt,type));
-            if max(Cr) <= cr_max && min(Cr) >= cr_min 
+            if max(Cr) <= cr_max && min(Cr) >= cr_min
                disp('Courant number constraints are already satisfied')
                return
             end
@@ -2866,7 +2866,7 @@ classdef msh
             % deleting boundary conditions which are difficult to recompute when
             % the triangulation changes
             obj.bd = []; obj.op = [];
-         
+
             if ~isempty(obj.coord)
                 % kjr 2018,10,17; Set up projected space imported from msh class
                 global MAP_PROJECTION MAP_VAR_LIST MAP_COORDS
@@ -2943,7 +2943,7 @@ classdef msh
                     [obj.p(:,1),obj.p(:,2)] = m_ll2xy(obj.p(:,1),obj.p(:,2));
                     bad = Cr < cr_min;
                     badnum = sum(bad);
-                    
+
                     display(['Number of minimum Cr bound violations ',num2str(badnum)]);
                     disp(['Min. Cr is : ',num2str(min(Cr))]);
                     if it == maxIT; break; end
@@ -2952,19 +2952,19 @@ classdef msh
 
                     % save old msh object for mapping
                     obj_old = obj;
-                    
+
                     % refine select elements using an octree approach
                     obj = RefineTrias(obj_old,bad);
 
                     % map back properties
                     obj = map_mesh_properties(obj,'msh_old',obj_old);
-                    
+
                     % put bathy back on with linear interp
                     obj.b = F(obj.p(:,1),obj.p(:,2));
 
                 end
             end
-                       
+
             % find nans
             if ~isempty(find(isnan(obj.b), 1))
                 warning('NaNs in bathy found')
@@ -2975,12 +2975,12 @@ classdef msh
 
             % Check Element order
             obj = CheckElementOrder(obj);
-           
+
             % Call itself recursively to make sure both criteria are satisifed
             obj = bound_courant_number(obj,dt,cr_max,cr_min,maxIT);
-      
-            % Last display message 
-            disp(['All msh attributes have been carried over except for boundary ' ... 
+
+            % Last display message
+            disp(['All msh attributes have been carried over except for boundary ' ...
                   'conditions which need to be recomputed. Since the triangulation ' ...
                   'has changed it may pay to recompute other attributes as well']);
             return;
@@ -3257,6 +3257,54 @@ classdef msh
             %                 strcat(Sta_name(Sta_type(:,1) == 1),' ID:',...
             %                 Sta_ID(Sta_type(:,1) == 1))];
 
+        end
+
+        function [m_remeshed] = remesh_patch(obj, poly, efdx, const_resolution)
+            %REMESH_PATCH Remeshes the region inside the given polygon.
+            %
+            % Syntax:
+            %   [m_remeshed] = remesh_patch(obj, poly, efdx, const_resolution)
+            %
+            % Inputs:
+            %   obj             - Mesh object containing the original mesh
+            %   poly            - Array of polygon vertices
+            %   efdx            - Background grid resolution (should be finer than intended min element size)
+            %   const_resolution- Optional, uniform resolution in the patch (in meters)
+            %
+            % Outputs:
+            %   m_remeshed      - Remeshed region
+            %
+            % Usage Example:
+            %   [m_remeshed] = remesh_patch(obj, poly, efdx)  % For variable resolution
+            %   [m_remeshed] = remesh_patch(obj, poly, efdx, 50) % For constant 50m resolution
+
+            % Check if const_resolution is specified
+            if nargin < 4
+                const_resolution = -999;
+            end
+
+            % Extract subdomain enclosed by the polygon
+            subdomain = extract_subdomain(obj, poly);
+
+            % Get polygon from subdomain
+            poly = get_poly(subdomain);
+
+            % Reconstruct edge function (ef) using subdomain and efdx
+            [ef, efx, efy] = reconstructEdgefx(subdomain, efdx, const_resolution);
+
+            % Create gridded interpolant function
+            fh = griddedInterpolant(efx, efy, ef);
+            hfun = @(p) fh(p);
+
+            % Generate new mesh for the subdomain
+            subdomain_new = mesh2dgen(poly, hfun);
+
+            % Extract subdomain with the hole
+            m_w_hole = extract_subdomain(obj, poly, "keep_inverse", 1);
+
+            % Combine the new and original subdomains
+            m_remeshed = plus(subdomain_new, m_w_hole, ...
+                'match', {'djc', 0.0, 'ds', 0, 'db', 0, 'con', 5, 'mqa', 1e-4, 'sc_maxit', 0});
         end
 
         function [ef,efx,efy]=reconstructEdgefx(obj,efdx)
@@ -3926,7 +3974,7 @@ classdef msh
             % Name value pairs specified.
             % Parse other varargin
             ind = [];
-            m_old = obj; 
+            m_old = obj;
             for kk = 1:2:length(varargin)
                 if strcmp(varargin{kk},'msh_old')
                     m_old = varargin{kk+1};
@@ -3997,7 +4045,7 @@ classdef msh
                     if ~isfield(obj.bd,'ibconn'); continue; end
                     if obj.bd.ibtype(ib) ~= 4 && obj.bd.ibtype(ib) ~= 5 && ...
                        obj.bd.ibtype(ib) ~= 24 && obj.bd.ibtype(ib) ~= 25
-                       continue; 
+                       continue;
                     end
                     idx_old = obj.bd.ibconn(1:nvell_old,ib);
                     % Only keep idx_old that is common to ind and map to ind
@@ -4024,7 +4072,7 @@ classdef msh
                     obj.bd = [];
                 else
                     % Remove unnessary part from the nbdv
-                    obj.bd.nbvv = obj.bd.nbvv(1:max(obj.bd.nvell),:);            
+                    obj.bd.nbvv = obj.bd.nbvv(1:max(obj.bd.nvell),:);
                     obj.bd.nbvv(:,obj.bd.nvell == 0) = [];
                     if isfield(obj.bd,'ibconn')
                         obj.bd.ibconn = obj.bd.ibconn(1:max(obj.bd.nvell),:);
@@ -4032,9 +4080,9 @@ classdef msh
                         obj.bd.barincfsb = obj.bd.barincfsb(1:max(obj.bd.nvell),:);
                         obj.bd.barincfsp = obj.bd.barincfsp(1:max(obj.bd.nvell),:);
                         obj.bd.ibconn(:,obj.bd.nvell == 0) = [];
-                        obj.bd.barinht(:,obj.bd.nvell == 0) = []; 
-                        obj.bd.barincfsb(:,obj.bd.nvell == 0) = []; 
-                        obj.bd.barincfsp(:,obj.bd.nvell == 0) = []; 
+                        obj.bd.barinht(:,obj.bd.nvell == 0) = [];
+                        obj.bd.barincfsb(:,obj.bd.nvell == 0) = [];
+                        obj.bd.barincfsp(:,obj.bd.nvell == 0) = [];
                     end
                     obj.bd.ibtype(obj.bd.nvell == 0) = [];
                     obj.bd.nvell(obj.bd.nvell == 0) = [];
@@ -4043,7 +4091,7 @@ classdef msh
             end
             % f13
             if ~isempty(m_old.f13)
-                obj.f13 = m_old.f13; 
+                obj.f13 = m_old.f13;
                 obj.f13.NumOfNodes = length(ind);
                 for att = 1:obj.f13.nAttr
                     % Get the old index for this attribute
@@ -4052,7 +4100,7 @@ classdef msh
                     % Only keep idx and val that is common to ind and map to ind
                     [~,ind_new,idx_new] = intersect(idx_old,ind);
                     val_new = val_old(:,ind_new);
-                    
+
                     % find indices of new nodes
                     [~,ind_added] = setdiff(obj.p,m_old.p,'rows');
                     if ~isempty(ind_added)
@@ -4064,12 +4112,12 @@ classdef msh
                         % for the new indices give the closest value in m_old
                         % for any given nodal attribute
                         tmp = ourKNNsearch(m_old.p',obj.p(ind_added,:)',1);
-                        val_new2 = values(tmp,:); 
+                        val_new2 = values(tmp,:);
                         idx_new = [idx_new; ind_added];
-                        val_new = [val_new'; val_new2]'; 
-                        [idx_new, C] = unique(idx_new); 
-                        val_new = val_new(:,C); 
-                    end                    
+                        val_new = [val_new'; val_new2]';
+                        [idx_new, C] = unique(idx_new);
+                        val_new = val_new(:,C);
+                    end
                     % Put the uservalues back into f13 struct
                     obj.f13.userval.Atr(att).AttrName = m_old.f13.userval.Atr(att).AttrName;
                     obj.f13.userval.Atr(att).Val = [idx_new'; val_new];
@@ -4301,7 +4349,7 @@ classdef msh
             sub1 = clean(sub1, {'ds',2,'mqa',1e-4,'djc',0.0,'con',5,'db',0,'sc_maxit',0});
             smoothed = plus(sub1,sub2,'match',{'djc',0.0,'ds',0,'db',0,'con',5,'mqa',1e-4,'sc_maxit',0});
         end
-          
+
         function obj= remove_attribute(obj, attrname)
             % obj = remove_attribute(obj, attrname)
             % Remove the attribute 'attrname' from the f13 field.
@@ -4314,10 +4362,10 @@ classdef msh
             % obj - msh object with f13 attribute removed.
             %
             % Author WJP, Mar, 2021
-       
+
             def_cell = {obj.f13.defval.Atr.AttrName};
             ii = find(contains(def_cell,attrname));
-            disp(['Removing attribute(s): ' def_cell{ii}]) 
+            disp(['Removing attribute(s): ' def_cell{ii}])
             obj.f13.defval.Atr(ii) = [];
             %
             user_cell = {obj.f13.userval.Atr.AttrName};

--- a/README.md
+++ b/README.md
@@ -157,15 +157,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Unreleased (on current HEAD of the Projection branch)
 ## Added
-- `namelist` and `RSTIMNC` input arguments for `Make_f15.m` fort.15 generator. updated the help message for all input argumebts to `Make_f15`. https://github.com/CHLNDDEV/OceanMesh2D/pull/283 
-- New stability namelist options to `Make_f15.m` fort.15 generator. https://github.com/CHLNDDEV/OceanMesh2D/pull/283 
+- Added new function in `msh` called `remesh_patch` to remesh within specified polygonal domains and insert back into parent mesh.
+- `namelist` and `RSTIMNC` input arguments for `Make_f15.m` fort.15 generator. updated the help message for all input argumebts to `Make_f15`. https://github.com/CHLNDDEV/OceanMesh2D/pull/283
+- New stability namelist options to `Make_f15.m` fort.15 generator. https://github.com/CHLNDDEV/OceanMesh2D/pull/283
 - Optionality for mesh2dgen to choose the method of mesh generation `kind`, and the maximum iteration count `iter`. https://github.com/CHLNDDEV/OceanMesh2D/pull/272
 - Option `improve_with_reduced_quality` to `meshgen` for allowing for mesh improvements even when quality is decreasing or large number of nodes eliminated, which sometimes is necessary to force the advancement in mesh quality.
 - Option `delaunay_elim_on_exit` to `meshgen` to skip the last call to `delaunay_elim` to potentially avoid deleting boundary elements.
 - Geoid offset nodal attribute in `Calc_f13` subroutine. https://github.com/CHLNDDEV/OceanMesh2D/pull/251
 - Support for writing Self Attraction and Loading (SAL) files in NetCDF for the ADCIRC model. https://github.com/CHLNDDEV/OceanMesh2D/pull/231
 ## Changed
-- removed namelists from default setup in `Make_f15.m` fort.15 generator to be invoked by user as an input argument instead. https://github.com/CHLNDDEV/OceanMesh2D/pull/283 
+- removed namelists from default setup in `Make_f15.m` fort.15 generator to be invoked by user as an input argument instead. https://github.com/CHLNDDEV/OceanMesh2D/pull/283
 - Use implicit smoother (`ds=1`) in `msh.clean` when fix points are present. https://github.com/CHLNDDEV/OceanMesh2D/pull/283
 - Default filename for the dynamicWaterLevelCorrection is now `null` so that it is not evoked by default. https://github.com/CHLNDDEV/OceanMesh2D/pull/272
 - Default mesh improvement strategy is `ds` 2.
@@ -173,7 +174,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `msh.offset63` struct and associated write/make routines for dynamicwaterlevel offset functionality. https://github.com/CHLNDDEV/OceanMesh2D/pull/259
 - dynamicWaterLevelCorrection to fort.15 namelist, and PRBCKGRND option to met fort.15 namelist. https://github.com/CHLNDDEV/OceanMesh2D/pull/261
 ## Fixed
-- writing out the wave coupling timestep `RSTIMNC` on the `WTIMNC` line of fort.15 when `NWS > 300`. https://github.com/CHLNDDEV/OceanMesh2D/pull/283 
+- writing out the wave coupling timestep `RSTIMNC` on the `WTIMNC` line of fort.15 when `NWS > 300`. https://github.com/CHLNDDEV/OceanMesh2D/pull/283
 - `make_bc` call with empty varargin, e.g., when calling inner. https://github.com/CHLNDDEV/OceanMesh2D/pull/283
 - `Make_offset63` call with constant offset (length 1 `time_vector`). https://github.com/CHLNDDEV/OceanMesh2D/pull/283
 - `ourKNNsearch` call in `nanfill` option of `Griddata` (`msh.interp`). https://github.com/CHLNDDEV/OceanMesh2D/pull/283


### PR DESCRIPTION
User can now re-remesh polygonal regions and seamlessly insert them back into the parent mesh. The merge back into the parent mesh assumes both the border between the parent and subdomain are identical (c.f., `msh.plus(...'match')`)

This simplifies example `Example_11_Remeshing_Patches.m`

#299 