### PR TITLE
Add empty cell filter into Read_shapefile.m

### DIFF
--- a/@geodata/private/Read_shapefile.m
+++ b/@geodata/private/Read_shapefile.m
@@ -132,6 +132,8 @@ if sr
     tmpC = mat2cell(tmpM,dims); % TO CELL
 else
     tmpC =  struct2cell(SG)';
+    % Remove empty cells from shapefile
+    tmpC = tmpC(~cellfun(@isempty,tmpC(:,1)),:);
     tmpCC = []; nn = 0;
     for ii = 1:size(tmpC,1)
         % may have NaNs inside

--- a/@geodata/private/Read_shapefile.m
+++ b/@geodata/private/Read_shapefile.m
@@ -132,8 +132,13 @@ if sr
     tmpC = mat2cell(tmpM,dims); % TO CELL
 else
     tmpC =  struct2cell(SG)';
+    
     % Remove empty cells from shapefile
-    tmpC = tmpC(~cellfun(@isempty,tmpC(:,1)),:);
+    if any(cellfun(@isempty,tmpC(:,1)))
+        warning('Empty objects in shapefile have been removed')
+        tmpC = tmpC(~cellfun(@isempty,tmpC(:,1)),:);
+    end
+
     tmpCC = []; nn = 0;
     for ii = 1:size(tmpC,1)
         % may have NaNs inside

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Unreleased (on current HEAD of the Projection branch)
 ## Added
-- Added a check in Read_shapefile.m to handle, warn, and correct cases where there are empty objects in a shapefile. https://github.com/CHLNDDEV/OceanMesh2D/pull/315
+- Added a check in `Read_shapefile.m` to handle, warn, and correct cases where there are empty objects in a shapefile. https://github.com/CHLNDDEV/OceanMesh2D/pull/315
 
 ### [6.0.0] - 2024-02-28
 ## Added

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Unreleased (on current HEAD of the Projection branch)
+## Added
+- Added a check in Read_shapefile.m to handle, warn, and correct cases where there are empty objects in a shapefile. https://github.com/CHLNDDEV/OceanMesh2D/pull/315
 
 ### [6.0.0] - 2024-02-28
 ## Added


### PR DESCRIPTION
When shapefiles are edited in QGIS, empty indexes can sometimes be created, which crashes the script. This line adds a check to see if there are any empty cells and removes them.