### PR TITLE
Bugfix for dropping edge constraints

### DIFF
--- a/@meshgen/meshgen.m
+++ b/@meshgen/meshgen.m
@@ -280,7 +280,7 @@ classdef meshgen
                             for j = 1 : length(obj.bou)
                                 if ~isempty(obj.bou{j}.weirEgfix) && ~isempty(obj.egfix)
                                     obj.egfix = [obj.egfix ; obj.bou{j}.weirEgfix+max(obj.egfix(:))];
-                                else
+                                elseif isempty(obj.egfix)
                                     obj.egfix =  obj.bou{j}.weirEgfix;
                                 end
                             end

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Unreleased (on current HEAD of the Projection branch)
+## Fixed 
+- User inputted edge constraints are now saved when no weirs are being constrained during mesh generation.
 
 ### [6.0.0] - 2024-02-28
 ## Added


### PR DESCRIPTION
* In the case no weirs are being constrained in mesh generation, save off user inputted edge constraints. 