### PR TITLE
Consider inner polygons w/ high fidelity

### DIFF
--- a/@meshgen/meshgen.m
+++ b/@meshgen/meshgen.m
@@ -525,6 +525,7 @@ classdef meshgen
                 ml = obj.mainland{box_num};
                 il = obj.inner{box_num};
                 polys = {};
+                if ~isempty(il), polys{end+1} = il; end
                 if ~isempty(ml), polys{end+1} = ml; end
                 
                 % High fidelity - formation of point & edge constraints

--- a/@meshgen/meshgen.m
+++ b/@meshgen/meshgen.m
@@ -521,15 +521,18 @@ classdef meshgen
             tpfix = [];
             tegfix = [];
             for box_num = 1:length(obj.h0)
-                % Define polygons based on available geometry data
-                ml = obj.mainland{box_num};
-                il = obj.inner{box_num};
-                polys = {};
-                if ~isempty(il), polys{end+1} = il; end
-                if ~isempty(ml), polys{end+1} = ml; end
+
                 
                 % High fidelity - formation of point & edge constraints
                 if obj.high_fidelity{box_num}
+
+                    % Define polygons based on available geometry data
+                    ml = obj.mainland{box_num};
+                    il = obj.inner{box_num};
+                    polys = {};
+                    if ~isempty(il), polys{end+1} = il; end
+                    if ~isempty(ml), polys{end+1} = ml; end
+                    
                     if obj.cleanup == 1
                         warning('Setting cleanup to 0 since high_fidelity mode is on');
                         obj.cleanup = 0;


### PR DESCRIPTION
When meshing with the high fidelity option, consider island/inner polygons to form additional breaklines in the mesh connectivity automatically.